### PR TITLE
Job filter should return empty list instead of error when id is not found #12

### DIFF
--- a/src/main/java/com/epam/grid/engine/entity/JobFilter.java
+++ b/src/main/java/com/epam/grid/engine/entity/JobFilter.java
@@ -50,4 +50,8 @@ public class JobFilter {
      * A list of job owners.
      */
     private List<String> owners;
+
+    public boolean idsIsNull() {
+        return ids != null;
+    }
 }

--- a/src/main/java/com/epam/grid/engine/entity/JobFilter.java
+++ b/src/main/java/com/epam/grid/engine/entity/JobFilter.java
@@ -50,8 +50,4 @@ public class JobFilter {
      * A list of job owners.
      */
     private List<String> owners;
-
-    public boolean idsIsNull() {
-        return ids != null;
-    }
 }

--- a/src/main/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProvider.java
+++ b/src/main/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProvider.java
@@ -161,4 +161,5 @@ public class SlurmJobProvider implements JobProvider {
     private boolean jobNotFoundByIdError(CommandResult result) {
         return result.getStdErr().toString().equals(jobIdNotFoundMessage);
     }
+
 }

--- a/src/main/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProvider.java
+++ b/src/main/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProvider.java
@@ -112,6 +112,27 @@ public class SlurmJobProvider implements JobProvider {
         return mapToJobListing(result.getStdOut());
     }
 
+    @Override
+    public Job runJob(final JobOptions options) {
+        throw new UnsupportedOperationException("Run job operation haven't implemented yet");
+    }
+
+    @Override
+    public DeletedJobInfo deleteJob(final DeleteJobFilter deleteJobFilter) {
+        throw new UnsupportedOperationException("Job deletion operation haven't implemented yet");
+    }
+
+    @Override
+    public JobLogInfo getJobLogInfo(final int jobId, final JobLogInfo.Type logType, final int lines,
+                                    final boolean fromHead) {
+        throw new UnsupportedOperationException("Job log info retrieving operation haven't implemented yet");
+    }
+
+    @Override
+    public InputStream getJobLogFile(final int jobId, final JobLogInfo.Type logType) {
+        throw new UnsupportedOperationException("Job log info file retrieving operation haven't implemented yet");
+    }
+
     /**
      * Creates the structure of an executable command based on the passed filter.
      *
@@ -135,27 +156,6 @@ public class SlurmJobProvider implements JobProvider {
                     .collect(Collectors.toList()));
         }
         return new Listing<>();
-    }
-
-    @Override
-    public Job runJob(final JobOptions options) {
-        throw new UnsupportedOperationException("Run job operation haven't implemented yet");
-    }
-
-    @Override
-    public DeletedJobInfo deleteJob(final DeleteJobFilter deleteJobFilter) {
-        throw new UnsupportedOperationException("Job deletion operation haven't implemented yet");
-    }
-
-    @Override
-    public JobLogInfo getJobLogInfo(final int jobId, final JobLogInfo.Type logType, final int lines,
-                                    final boolean fromHead) {
-        throw new UnsupportedOperationException("Job log info retrieving operation haven't implemented yet");
-    }
-
-    @Override
-    public InputStream getJobLogFile(final int jobId, final JobLogInfo.Type logType) {
-        throw new UnsupportedOperationException("Job log info file retrieving operation haven't implemented yet");
     }
 
     private boolean jobNotFoundByIdError(CommandResult result) {

--- a/src/main/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProvider.java
+++ b/src/main/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProvider.java
@@ -137,10 +137,6 @@ public class SlurmJobProvider implements JobProvider {
         return new Listing<>();
     }
 
-    private boolean jobNotFoundByIdError(CommandResult result) {
-        return result.getStdErr().toString().equals(jobIdNotFoundMessage);
-    }
-
     @Override
     public Job runJob(final JobOptions options) {
         throw new UnsupportedOperationException("Run job operation haven't implemented yet");
@@ -162,4 +158,7 @@ public class SlurmJobProvider implements JobProvider {
         throw new UnsupportedOperationException("Job log info file retrieving operation haven't implemented yet");
     }
 
+    private boolean jobNotFoundByIdError(CommandResult result) {
+        return result.getStdErr().toString().equals(jobIdNotFoundMessage);
+    }
 }

--- a/src/main/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProvider.java
+++ b/src/main/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProvider.java
@@ -87,7 +87,8 @@ public class SlurmJobProvider implements JobProvider {
                             final SimpleCmdExecutor simpleCmdExecutor,
                             final GridEngineCommandCompiler commandCompiler,
                             @Value("${slurm.job.output-fields-count:52}") final int fieldsCount,
-                            @Value("${SLURM_JOB_NOT_FOUND_MESSAGE:[slurm_load_jobs error: Invalid job id specified]}") final String jobIdNotFoundMessage) {
+                            @Value("${SLURM_JOB_NOT_FOUND_MESSAGE:[slurm_load_jobs error: Invalid job id specified]}")
+                            final String jobIdNotFoundMessage) {
         this.jobMapper = jobMapper;
         this.simpleCmdExecutor = simpleCmdExecutor;
         this.commandCompiler = commandCompiler;
@@ -102,7 +103,7 @@ public class SlurmJobProvider implements JobProvider {
 
     @Override
     public Listing<Job> filterJobs(final JobFilter jobFilter) {
-        SacctCommandParser.filterCorrectJobIds(jobFilter.getIds());
+        SacctCommandParser.filterCorrectJobIds(jobFilter);
         final CommandResult result = simpleCmdExecutor.execute(makeSqueueCommand(jobFilter));
         if (result.getExitCode() != 0 && !jobNotFoundByIdError(result)) {
             CommandsUtils.throwExecutionDetails(result);
@@ -158,8 +159,7 @@ public class SlurmJobProvider implements JobProvider {
         return new Listing<>();
     }
 
-    private boolean jobNotFoundByIdError(CommandResult result) {
+    private boolean jobNotFoundByIdError(final CommandResult result) {
         return result.getStdErr().toString().equals(jobIdNotFoundMessage);
     }
-
 }

--- a/src/main/java/com/epam/grid/engine/provider/utils/slurm/job/SacctCommandParser.java
+++ b/src/main/java/com/epam/grid/engine/provider/utils/slurm/job/SacctCommandParser.java
@@ -121,9 +121,11 @@ public final class SacctCommandParser {
     }
 
     public static void filterCorrectJobIds(final List<Integer> jobIds) {
-        jobIds.stream().filter(id -> id < 1).findFirst().ifPresent(id -> {
-            throw new GridEngineException(HttpStatus.BAD_REQUEST,
-                    "Only positive ids should be provided for filtration");
-        });
+        jobIds.stream().filter(id -> id < 1)
+                .findFirst()
+                .ifPresent(id -> {
+                    throw new GridEngineException(HttpStatus.BAD_REQUEST,
+                            "Only positive ids should be provided for filtration");
+                });
     }
 }

--- a/src/main/java/com/epam/grid/engine/provider/utils/slurm/job/SacctCommandParser.java
+++ b/src/main/java/com/epam/grid/engine/provider/utils/slurm/job/SacctCommandParser.java
@@ -19,6 +19,7 @@
 
 package com.epam.grid.engine.provider.utils.slurm.job;
 
+import com.epam.grid.engine.entity.JobFilter;
 import com.epam.grid.engine.entity.job.slurm.SlurmJob;
 import com.epam.grid.engine.exception.GridEngineException;
 import com.epam.grid.engine.provider.utils.DateUtils;
@@ -121,12 +122,15 @@ public final class SacctCommandParser {
                 : null;
     }
 
-    public static void filterCorrectJobIds(final List<Integer> jobIds) {
-        jobIds.stream().filter(id -> id < 1)
-                .findFirst()
-                .ifPresent(id -> {
-                    throw new GridEngineException(HttpStatus.BAD_REQUEST,
-                            "Only positive ids should be provided for filtration");
-                });
+    public static void filterCorrectJobIds(final JobFilter jobFilter) {
+        if (jobFilter.idsIsNull() && jobFilter.getIds().size() > 0) {
+            final List<Integer> jobIds = jobFilter.getIds();
+            jobIds.stream().filter(id -> id < 1)
+                    .findFirst()
+                    .ifPresent(id -> {
+                        throw new GridEngineException(HttpStatus.BAD_REQUEST,
+                                "Only positive ids should be provided for filtration");
+                    });
+        }
     }
 }

--- a/src/main/java/com/epam/grid/engine/provider/utils/slurm/job/SacctCommandParser.java
+++ b/src/main/java/com/epam/grid/engine/provider/utils/slurm/job/SacctCommandParser.java
@@ -120,4 +120,10 @@ public final class SacctCommandParser {
                 : null;
     }
 
+    public static void filterCorrectJobIds(final List<Integer> jobIds) {
+        jobIds.stream().filter(id -> id < 1).findFirst().ifPresent(id -> {
+            throw new GridEngineException(HttpStatus.BAD_REQUEST,
+                    "Only positive ids should be provided for filtration");
+        });
+    }
 }

--- a/src/main/java/com/epam/grid/engine/provider/utils/slurm/job/SacctCommandParser.java
+++ b/src/main/java/com/epam/grid/engine/provider/utils/slurm/job/SacctCommandParser.java
@@ -29,7 +29,9 @@ import org.springframework.http.HttpStatus;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.epam.grid.engine.utils.TextConstants.COMMA;
@@ -123,14 +125,14 @@ public final class SacctCommandParser {
     }
 
     public static void filterCorrectJobIds(final JobFilter jobFilter) {
-        if (jobFilter.idsIsNull() && jobFilter.getIds().size() > 0) {
-            final List<Integer> jobIds = jobFilter.getIds();
-            jobIds.stream().filter(id -> id < 1)
-                    .findFirst()
-                    .ifPresent(id -> {
-                        throw new GridEngineException(HttpStatus.BAD_REQUEST,
-                                "Only positive ids should be provided for filtration");
-                    });
-        }
+        Optional.ofNullable(jobFilter).map(JobFilter::getIds)
+                .stream()
+                .flatMap(Collection::stream)
+                .filter(jobId -> jobId < 1)
+                .findFirst()
+                .ifPresent(id -> {
+                    throw new GridEngineException(HttpStatus.BAD_REQUEST,
+                            "Only positive ids should be provided for filtration");
+                });
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,3 +35,4 @@ sge.parallel.environment.registration.default.allocation.rule=${GRID_ENGINE_API_
 
 #SLURM specific properties
 slurm.job.output-fields-count=${SLURM_JOB_FIELDS_COUNT:52}
+slurm.job.job-not-found-message=${SLURM_JOB_NOT_FOUND_MESSAGE:[slurm_load_jobs error: Invalid job id specified]}


### PR DESCRIPTION
Job filter should return empty list instead of error when id is not found #12

Bug during job filtration using ids was fixed
- If incorrect ids were provided, an exception will be thrown before filtration
- If a jobs wasn't found by provided id, an empty array will be returned insted of exception
- PR allows to filter jobs using ids properly