### PR TITLE
Unable to start job with env vars or argument with spaces #15

### DIFF
--- a/src/main/java/com/epam/grid/engine/cmd/CommandArgUtils.java
+++ b/src/main/java/com/epam/grid/engine/cmd/CommandArgUtils.java
@@ -28,6 +28,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import static com.epam.grid.engine.utils.TextConstants.SPACE;
+import static com.epam.grid.engine.utils.TextConstants.APOSTROPHE;
+import static com.epam.grid.engine.utils.TextConstants.SINGLE_QUOTE_SIGN;
 
 /**
  * This class performs the formation of the structure of the executed command
@@ -37,7 +39,6 @@ import static com.epam.grid.engine.utils.TextConstants.SPACE;
 public class CommandArgUtils {
 
     private static final String DELIMITERS = " \\" + System.lineSeparator();
-    private static final String APOSTROPHE = "\"";
 
     /**
      * This method forms a command structure from a string command.
@@ -62,9 +63,9 @@ public class CommandArgUtils {
         final StringBuilder quotedPart = new StringBuilder();
 
         for (String commandPart : commandParts) {
-            if (commandPart.startsWith(APOSTROPHE)) {
+            if (commandPart.startsWith(APOSTROPHE) || commandPart.startsWith(SINGLE_QUOTE_SIGN)) {
                 appendCommandToBuilder(quotedPart, commandPart);
-            } else if (commandPart.endsWith(APOSTROPHE)) {
+            } else if (commandPart.endsWith(APOSTROPHE) || commandPart.endsWith(SINGLE_QUOTE_SIGN)) {
                 appendCommandToBuilder(quotedPart, commandPart);
                 dumpQuotedToResults(quotedPart, result);
             } else {
@@ -77,7 +78,8 @@ public class CommandArgUtils {
 
     private static void addQuotedPartToBuilderOrDump(final String commandPart, final StringBuilder quotedPart,
                                                      final List<String> result) {
-        if (quotedPart.length() != 0 && !quotedPart.toString().endsWith(APOSTROPHE)) {
+        if (quotedPart.length() != 0 && !quotedPart.toString().endsWith(APOSTROPHE)
+                && !quotedPart.toString().endsWith(SINGLE_QUOTE_SIGN)) {
             appendCommandToBuilder(quotedPart, commandPart);
         } else {
             dumpQuotedToResultsIfPresent(quotedPart, result);

--- a/src/main/java/com/epam/grid/engine/utils/TextConstants.java
+++ b/src/main/java/com/epam/grid/engine/utils/TextConstants.java
@@ -32,4 +32,6 @@ public final class TextConstants {
     public static final String NEW_LINE_DELIMITER = "\n";
     public static final String SPACE = " ";
     public static final String NONE = "NONE";
+    public static final String APOSTROPHE = "\"";
+    public static final String SINGLE_QUOTE_SIGN = "'";
 }

--- a/src/main/resources/templates/sge/command/qsub
+++ b/src/main/resources/templates/sge/command/qsub
@@ -38,7 +38,7 @@ qsub
 -o [(${logDir})]$JOB_ID.out
 [/]
 [# th:if="${envVariables != null}"]
--v [(${envVariables})]
+-v "[(${envVariables})]"
 [/]
 [(${options.command})]
 [# th:if="${not #lists.isEmpty(options.arguments)}"]

--- a/src/test/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProviderTest.java
+++ b/src/test/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProviderTest.java
@@ -143,9 +143,9 @@ public class SlurmJobProviderTest {
     private static final String SBATCH = "sbatch";
     private static final String ENV_VARIABLES = "envVariables";
     private static final String ENV_VAR_KEY = "parameter1";
-    private static final String ENV_VAR_VALUE = "parameter1Value";
-    private static final String ENV_VAR_MAP_ENTRY = "parameter1=parameter1Value";
-    private static final String ENV_VAR_FLAG = "--export=";
+    private static final String ENV_VAR_VALUE = "parameter one value with spaces";
+    private static final String ENV_VAR_MAP_ENTRY = "parameter1=parameter one value with spaces";
+    private static final String ENV_VAR_FLAG = "--export ";
     private static final String ENV_VAR_MAP_ONLY_KEY = "parameter1";
     private static final String JOB_PRIORITY4 = "9999";
     private static final String JOB_NAME4 = "newSlurmJob";
@@ -426,6 +426,14 @@ public class SlurmJobProviderTest {
         Assertions.assertNotNull(thrown.getMessage());
     }
 
+    @ParameterizedTest
+    @MethodSource("provideIllegalArgumentJobOptions")
+    public void shouldThrowIllegalArumentExceptionMakingSbatchCommand(final JobOptions jobOptions) {
+        final Throwable thrown = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> slurmJobProvider.runJob(jobOptions));
+        Assertions.assertNotNull(thrown.getMessage());
+    }
+
     static Stream<Arguments> provideInvalidJobOptions() {
         return Stream.of(
                 Arguments.of(JobOptions.builder().command(null).build()),
@@ -435,9 +443,14 @@ public class SlurmJobProviderTest {
 
     static Stream<Arguments> provideUnsupportedJobOptions() {
         return Stream.of(
-                Arguments.of(JobOptions.builder().priority(-100)
-                        .command(JOB_NAME1).build()),
                 Arguments.of(JobOptions.builder().parallelEnvOptions(new ParallelEnvOptions(EMPTY_STRING, 1, 10))
+                        .command(JOB_NAME1).build())
+        );
+    }
+
+    static Stream<Arguments> provideIllegalArgumentJobOptions() {
+        return Stream.of(
+                Arguments.of(JobOptions.builder().priority(-100)
                         .command(JOB_NAME1).build())
         );
     }
@@ -501,11 +514,11 @@ public class SlurmJobProviderTest {
 
     static Stream<Arguments> provideCorrectSbatchCommands() {
         return mapObjectsToArgumentsStream(
-                new String[]{SBATCH, "--export=", ENV_VAR_MAP_ENTRY, JOB_NAME1},
+                new String[]{SBATCH, "--export ", ENV_VAR_MAP_ENTRY, JOB_NAME1},
                 new String[]{SBATCH, "--priority=", JOB_PRIORITY4, JOB_NAME1},
-                new String[]{SBATCH, "-J", JOB_NAME4, JOB_NAME1},
+                new String[]{SBATCH, "--job-name=", JOB_NAME4, JOB_NAME1},
                 new String[]{SBATCH, "--partition=", JOB_PARTITION, JOB_NAME1},
-                new String[]{SBATCH, "-D", JOB_WORK_DIR, JOB_NAME1}
+                new String[]{SBATCH, "--chdir=", JOB_WORK_DIR, JOB_NAME1}
         );
     }
 


### PR DESCRIPTION
Unable to start job with env vars or argument with spaces #15
========================================================================
This PR resolves the bug of vars with spaces in environment variables in SGE and options with spaces in SLURM

SGE template was changed and services classes, which processed the given command with options.
Tests were modified if needed

These changes allows to set environment variables and options with spaces
