### PR TITLE
Fix problem with priority option when submit job #16

### DIFF
--- a/src/main/java/com/epam/grid/engine/entity/job/JobOptions.java
+++ b/src/main/java/com/epam/grid/engine/entity/job/JobOptions.java
@@ -59,7 +59,7 @@ public class JobOptions {
     /**
      * Job priority.
      */
-    private int priority;
+    private Long priority;
     /**
      * A list of queues in which the job should be processed.
      */

--- a/src/main/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProvider.java
+++ b/src/main/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProvider.java
@@ -178,7 +178,7 @@ public class SlurmJobProvider implements JobProvider {
         if (!StringUtils.hasText(options.getCommand())) {
             throw new GridEngineException(HttpStatus.BAD_REQUEST, "Command should be specified!");
         }
-        if (options.getPriority() < 0) {
+        if (options.getPriority() != null && options.getPriority() < 1L) {
             throw new IllegalArgumentException("Priority should be between 0 and 4_294_967_294");
         }
         if (options.getParallelEnvOptions() != null) {

--- a/src/main/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProvider.java
+++ b/src/main/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProvider.java
@@ -179,7 +179,7 @@ public class SlurmJobProvider implements JobProvider {
             throw new GridEngineException(HttpStatus.BAD_REQUEST, "Command should be specified!");
         }
         if (options.getPriority() != null && options.getPriority() < 1L) {
-            throw new IllegalArgumentException("Priority should be between 0 and 4_294_967_294");
+            throw new IllegalArgumentException("Priority should be between 1 and 4_294_967_294");
         }
         if (options.getParallelEnvOptions() != null) {
             throw new UnsupportedOperationException("Parallel environment variables are not supported yet!");

--- a/src/test/java/com/epam/grid/engine/cmd/GridEngineCommandCompilerImplTest.java
+++ b/src/test/java/com/epam/grid/engine/cmd/GridEngineCommandCompilerImplTest.java
@@ -554,7 +554,7 @@ public class GridEngineCommandCompilerImplTest {
                         new String[]{QSUB, NAME_OPTION, JOB_NAME, JOB_COMMAND}),
                 Arguments.of(getSimpleJobCommand().workingDir(WORK_DIR_NAME),
                         new String[]{QSUB, WORK_DIR_OPTION, WORK_DIR_NAME, JOB_COMMAND}),
-                Arguments.of(getSimpleJobCommand().priority(Integer.parseInt(PRIORITY)),
+                Arguments.of(getSimpleJobCommand().priority(Long.parseLong(PRIORITY)),
                         new String[]{QSUB, PRIORITY_OPTION, PRIORITY, JOB_COMMAND}),
                 Arguments.of(getSimpleJobCommand().queues(List.of(QUEUE, QUEUE2)),
                         new String[]{QSUB, QUEUES_OPTION, QUEUE, QUEUE2, JOB_COMMAND}),

--- a/src/test/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProviderTest.java
+++ b/src/test/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProviderTest.java
@@ -75,9 +75,9 @@ public class SlurmJobProviderTest {
     private static final String JOB_NAME1 = "test.sh";
     private static final String JOB_NAME2 = "test3.sh";
     private static final String JOB_NAME3 = "test.sh";
-    private static final double JOB_PRIORITY1 = 0.99998474121093;
-    private static final double JOB_PRIORITY2 = 0.99998474074527;
-    private static final double JOB_PRIORITY3 = 0.00000000000000;
+    private static final Long JOB_PRIORITY1 = 999_999_999L;
+    private static final Long JOB_PRIORITY2 = 2_200_000_000L;
+    private static final Long JOB_PRIORITY3 = 0L;
     private static final List<String> NAME = Collections.singletonList(JOB_NAME1);
     private static final List<Integer> ID = Collections.singletonList(7);
 
@@ -89,7 +89,7 @@ public class SlurmJobProviderTest {
                     + "TIME_LEFT|TIME|NODELIST|CONTIGUOUS|PARTITION|PRIORITY|NODELIST(REASON)|START_TIME|STATE|UID|"
                     + "SUBMIT_TIME|LICENSES|CORE_SPEC|SCHEDNODES|WORK_DIR",
             "(null)|N/A|1|0|2022-05-18T10:29:10|(null)|root|OK|2|test.sh|(null)|5-00:00:00|500M||/data/test.sh|"
-                    + "0.99998474121093|normal|None||R|root|(null)|(null)||0|*:*:*|2|worker1|1|1||2|0|*|*|*|N/A|"
+                    + "9.99999999E8|normal|None||R|root|(null)|(null)||0|*:*:*|2|worker1|1|1||2|0|*|*|*|N/A|"
                     + "4-21:35:49|2:24:11|worker1|0|normal|4294901759|worker1|2022-05-13T10:29:10|RUNNING|0|"
                     + "2022-05-13T10:29:09|(null)|N/A|(null)|/");
 
@@ -99,11 +99,11 @@ public class SlurmJobProviderTest {
                     + "CPUS|NODES|DEPENDENCY|ARRAY_JOB_ID|GROUP|SOCKETS_PER_NODE|CORES_PER_SOCKET|THREADS_PER_CORE|"
                     + "ARRAY_TASK_ID|TIME_LEFT|TIME|NODELIST|CONTIGUOUS|PARTITION|PRIORITY|NODELIST(REASON)|START_TIME|"
                     + "STATE|UID|SUBMIT_TIME|LICENSES|CORE_SPEC|SCHEDNODES|WORK_DIR",
-            "(null)|N/A|1|0|N/A|(null)|root|OK|4|test3.sh|(null)|5-00:00:00|500M||/data/test3.sh|0.99998474074527|"
+            "(null)|N/A|1|0|N/A|(null)|root|OK|4|test3.sh|(null)|5-00:00:00|500M||/data/test3.sh|2.2E9|"
                     + "normal|Resources||PD|root|(null)|(null)||0|*:*:*|4|n/a|1|1||4|0|*|*|*|N/A|5-00:00:00|0:00||0|"
                     + "normal|4294901757|(Resources)|N/A|PENDING|0|2022-05-15T08:03:42|(null)|N/A|(null)|/",
             "(null)|N/A|1|0|2022-05-18T10:29:10|(null)|root|OK|2|test.sh|(null)|5-00:00:00|500M||/data/test.sh|"
-                    + "0.99998474121093|normal|None||R|root|(null)|(null)||0|*:*:*|2|worker1|1|1||2|0|*|*|*|N/A|"
+                    + "9.99999999E8|normal|None||R|root|(null)|(null)||0|*:*:*|2|worker1|1|1||2|0|*|*|*|N/A|"
                     + "4-21:35:49|2:24:11|worker1|0|normal|4294901759|worker1|2022-05-13T10:29:10|RUNNING|0|"
                     + "2022-05-13T10:29:09|(null)|N/A|(null)|/");
     private static final List<String> THREE_VALID_JOBS_STDOUT = List.of("ACCOUNT|TRES_PER_NODE|MIN_CPUS|MIN_TMP_DISK|"
@@ -116,11 +116,11 @@ public class SlurmJobProviderTest {
                     + "0.00000000000000|normal|None||S|root|(null)|(null)||0|*:*:*|5|worker1|1|1||2|0|*|*|*|N/A|"
                     + "4-18:52:51|5:07:09|worker1|0|normal|0|worker1|2022-05-15T08:03:38|SUSPENDED|0|"
                     + "2022-05-15T08:03:37|(null)|N/A|(null)|/",
-            "(null)|N/A|1|0|N/A|(null)|root|OK|4|test3.sh|(null)|5-00:00:00|500M||/data/test3.sh|0.99998474074527|"
+            "(null)|N/A|1|0|N/A|(null)|root|OK|4|test3.sh|(null)|5-00:00:00|500M||/data/test3.sh|2.2E9|"
                     + "normal|Resources||PD|root|(null)|(null)||0|*:*:*|4|n/a|1|1||4|0|*|*|*|N/A|5-00:00:00|0:00||0|"
                     + "normal|4294901757|(Resources)|N/A|PENDING|0|2022-05-15T08:03:42|(null)|N/A|(null)|/",
             "(null)|N/A|1|0|2022-05-18T10:29:10|(null)|root|OK|2|test.sh|(null)|5-00:00:00|500M||/data/test.sh|"
-                    + "0.99998474121093|normal|None||R|root|(null)|(null)||0|*:*:*|2|worker1|1|1||2|0|*|*|*|N/A|"
+                    + "9.99999999E8|normal|None||R|root|(null)|(null)||0|*:*:*|2|worker1|1|1||2|0|*|*|*|N/A|"
                     + "4-21:35:49|2:24:11|worker1|0|normal|4294901759|worker1|2022-05-13T10:29:10|RUNNING|0|"
                     + "2022-05-13T10:29:09|(null)|N/A|(null)|/");
 
@@ -450,7 +450,7 @@ public class SlurmJobProviderTest {
 
     static Stream<Arguments> provideIllegalArgumentJobOptions() {
         return Stream.of(
-                Arguments.of(JobOptions.builder().priority(-100)
+                Arguments.of(JobOptions.builder().priority(-100L)
                         .command(JOB_NAME1).build())
         );
     }


### PR DESCRIPTION
Fix problem with priority option when submit job #16
1.JobOption priority type was changed from int to Long to allow to user to set greater priority in Slurm (max is unsigned int)
2.Check for 0 priority in slurm was added as there is no way now to change priority in existed job, and a job with 0 priority cannot be started later.
3.Tests were changed if needed