### PR TITLE
Grid engine api uses relative paths to configure job log directory #17

### DIFF
--- a/src/main/java/com/epam/grid/engine/provider/job/sge/SgeJobProvider.java
+++ b/src/main/java/com/epam/grid/engine/provider/job/sge/SgeJobProvider.java
@@ -127,11 +127,11 @@ public class SgeJobProvider implements JobProvider {
                           final SimpleCmdExecutor simpleCmdExecutor,
                           final GridEngineCommandCompiler commandCompiler,
                           @Value("${job.log.dir}") final String logDir,
-                          @Value("${grid.engine.shared.folder}") final String gridEngineFolder) {
+                          @Value("${grid.engine.shared.folder}") final String gridSharedFolder) {
         this.jobMapper = jobMapper;
         this.simpleCmdExecutor = simpleCmdExecutor;
         this.commandCompiler = commandCompiler;
-        this.logDir = DirectoryPathUtils.buildProperDir(logDir, gridEngineFolder);
+        this.logDir = DirectoryPathUtils.buildProperDir(gridSharedFolder, logDir);
     }
 
     /**

--- a/src/main/java/com/epam/grid/engine/provider/job/sge/SgeJobProvider.java
+++ b/src/main/java/com/epam/grid/engine/provider/job/sge/SgeJobProvider.java
@@ -131,7 +131,7 @@ public class SgeJobProvider implements JobProvider {
         this.jobMapper = jobMapper;
         this.simpleCmdExecutor = simpleCmdExecutor;
         this.commandCompiler = commandCompiler;
-        this.logDir = DirectoryPathUtils.buildProperDir(gridSharedFolder, logDir);
+        this.logDir = DirectoryPathUtils.buildProperDir(gridSharedFolder, logDir).toString();
     }
 
     /**

--- a/src/main/java/com/epam/grid/engine/provider/job/sge/SgeJobProvider.java
+++ b/src/main/java/com/epam/grid/engine/provider/job/sge/SgeJobProvider.java
@@ -38,6 +38,7 @@ import com.epam.grid.engine.entity.job.sge.SgeQueueListing;
 import com.epam.grid.engine.mapper.job.sge.SgeJobMapper;
 import com.epam.grid.engine.exception.GridEngineException;
 import com.epam.grid.engine.provider.job.JobProvider;
+import com.epam.grid.engine.provider.utils.DirectoryPathUtils;
 import com.epam.grid.engine.provider.utils.JaxbUtils;
 import com.epam.grid.engine.provider.utils.sge.job.QstatCommandParser;
 import com.epam.grid.engine.provider.utils.CommandsUtils;
@@ -125,11 +126,12 @@ public class SgeJobProvider implements JobProvider {
     public SgeJobProvider(final SgeJobMapper jobMapper,
                           final SimpleCmdExecutor simpleCmdExecutor,
                           final GridEngineCommandCompiler commandCompiler,
-                          @Value("${job.log.dir}") final String logDir) {
+                          @Value("${job.log.dir}") final String logDir,
+                          @Value("${grid.engine.shared.folder}") final String gridEngineFolder) {
         this.jobMapper = jobMapper;
         this.simpleCmdExecutor = simpleCmdExecutor;
         this.commandCompiler = commandCompiler;
-        this.logDir = logDir;
+        this.logDir = DirectoryPathUtils.buildProperDir(logDir, gridEngineFolder);
     }
 
     /**

--- a/src/main/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProvider.java
+++ b/src/main/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProvider.java
@@ -129,7 +129,7 @@ public class SlurmJobProvider implements JobProvider {
         this.commandCompiler = commandCompiler;
         this.fieldsCount = fieldsCount;
         this.jobIdNotFoundMessage = jobIdNotFoundMessage;
-        this.logDir = DirectoryPathUtils.buildProperDir(gridSharedFolder, logDir);
+        this.logDir = DirectoryPathUtils.buildProperDir(gridSharedFolder, logDir).toString();
     }
 
     @Override

--- a/src/main/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProvider.java
+++ b/src/main/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProvider.java
@@ -123,13 +123,13 @@ public class SlurmJobProvider implements JobProvider {
                             @Value("${SLURM_JOB_NOT_FOUND_MESSAGE:slurm_load_jobs error: Invalid job id specified}")
                             final String jobIdNotFoundMessage,
                             @Value("${job.log.dir}") final String logDir,
-                            @Value("${grid.engine.shared.folder}") final String gridEngineFolder) {
+                            @Value("${grid.engine.shared.folder}") final String gridSharedFolder) {
         this.jobMapper = jobMapper;
         this.simpleCmdExecutor = simpleCmdExecutor;
         this.commandCompiler = commandCompiler;
         this.fieldsCount = fieldsCount;
         this.jobIdNotFoundMessage = jobIdNotFoundMessage;
-        this.logDir = DirectoryPathUtils.buildProperDir(logDir, gridEngineFolder);
+        this.logDir = DirectoryPathUtils.buildProperDir(gridSharedFolder, logDir);
     }
 
     @Override

--- a/src/main/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProvider.java
+++ b/src/main/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProvider.java
@@ -37,6 +37,7 @@ import com.epam.grid.engine.mapper.job.slurm.SlurmJobMapper;
 import com.epam.grid.engine.provider.job.JobProvider;
 
 import com.epam.grid.engine.provider.utils.CommandsUtils;
+import com.epam.grid.engine.provider.utils.DirectoryPathUtils;
 import com.epam.grid.engine.provider.utils.slurm.job.SacctCommandParser;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.ListUtils;
@@ -118,18 +119,17 @@ public class SlurmJobProvider implements JobProvider {
     public SlurmJobProvider(final SlurmJobMapper jobMapper,
                             final SimpleCmdExecutor simpleCmdExecutor,
                             final GridEngineCommandCompiler commandCompiler,
-                            @Value("${slurm.job.output-fields-count:52}")
-                            final int fieldsCount,
+                            @Value("${slurm.job.output-fields-count:52}") final int fieldsCount,
                             @Value("${SLURM_JOB_NOT_FOUND_MESSAGE:slurm_load_jobs error: Invalid job id specified}")
                             final String jobIdNotFoundMessage,
-                            @Value("${job.log.dir}")
-                            final String logDir) {
+                            @Value("${job.log.dir}") final String logDir,
+                            @Value("${grid.engine.shared.folder}") final String gridEngineFolder) {
         this.jobMapper = jobMapper;
         this.simpleCmdExecutor = simpleCmdExecutor;
         this.commandCompiler = commandCompiler;
         this.fieldsCount = fieldsCount;
         this.jobIdNotFoundMessage = jobIdNotFoundMessage;
-        this.logDir = logDir;
+        this.logDir = DirectoryPathUtils.buildProperDir(logDir, gridEngineFolder);
     }
 
     @Override

--- a/src/main/java/com/epam/grid/engine/provider/utils/DirectoryPathUtils.java
+++ b/src/main/java/com/epam/grid/engine/provider/utils/DirectoryPathUtils.java
@@ -69,8 +69,9 @@ public final class DirectoryPathUtils {
                 log.info("Directory with path " + folderToCreate + " was created.");
                 try {
                     grantAllPermissionsToFolder(folderToCreate);
-                } catch (IOException e) {
-                    throw new IllegalArgumentException("Failed to grant permissions to the path " + folderToCreate, e);
+                } catch (IOException ioException) {
+                    throw new IllegalArgumentException("Failed to grant permissions to the path " + folderToCreate,
+                            ioException);
                 }
             } else {
                 throw new IllegalArgumentException("Failed to create directory with path " + folderToCreate);

--- a/src/main/java/com/epam/grid/engine/provider/utils/DirectoryPathUtils.java
+++ b/src/main/java/com/epam/grid/engine/provider/utils/DirectoryPathUtils.java
@@ -44,18 +44,17 @@ public final class DirectoryPathUtils {
      * creates, if needed.
      *
      * @param nestedFolder Directory, which should be checked for correction path
-     * @param rootFolder Primary working directory from properties
+     * @param rootFolder   Primary working directory from properties
      * @return Adjusted directory path with added primary directory added if needed
      */
+    @SuppressWarnings("PMD.PreserveStackTrace")
     public static String buildProperDir(final String rootFolder, final String nestedFolder) {
         final StringBuilder properDir = new StringBuilder();
         final File nestedFolderPath = new File(nestedFolder);
         if (nestedFolderPath.isAbsolute()) {
             if (!nestedFolder.startsWith(rootFolder)) {
-                final String errorMessage = "Nested folder path is absolute, but doesn't start with " +
-                        "grid.engine.shared.folder";
-                log.error(errorMessage);
-                throw new IllegalStateException(errorMessage);
+                throw new IllegalStateException("Nested folder path is absolute, but doesn't start with "
+                        + "grid.engine.shared.folder");
             }
             if (!nestedFolderPath.exists()) {
                 try {
@@ -66,8 +65,8 @@ public final class DirectoryPathUtils {
                         throw new IOException("Failed to create directory with path " + nestedFolderPath);
                     }
                 } catch (final Exception exception) {
-                    log.error(exception.getMessage());
-                    exception.printStackTrace();
+                    throw new IllegalArgumentException("Failed to create a directory by provided path: "
+                            + nestedFolderPath + ". " + exception.getMessage());
                 }
             }
             properDir.append(nestedFolderPath);
@@ -88,21 +87,22 @@ public final class DirectoryPathUtils {
                         throw new IOException("Failed to create directory with path " + gridEnginePath);
                     }
                 } catch (final Exception exception) {
-                    log.error(exception.getMessage());
-                    exception.printStackTrace();
+                    throw new IllegalArgumentException("Failed to create a directory by provided path: "
+                            + gridEnginePath + ". " + exception.getMessage());
                 }
             }
         }
         return properDir.toString();
     }
 
+    @SuppressWarnings("PMD.PreserveStackTrace")
     private static void grantAllPermissionsToFolder(final File directory) {
         try {
             final Set<PosixFilePermission> permissions = PosixFilePermissions.fromString(ALL_PERMISSIONS_STRING);
             Files.setPosixFilePermissions(directory.toPath(), permissions);
         } catch (final IOException exception) {
-            log.error("Error while granting permissions to " + directory);
-            exception.printStackTrace();
+            throw new IllegalArgumentException("Failed to grant permissions to the provided directory "
+                    + directory + ". " + exception.getMessage());
         }
     }
 }

--- a/src/main/java/com/epam/grid/engine/provider/utils/DirectoryPathUtils.java
+++ b/src/main/java/com/epam/grid/engine/provider/utils/DirectoryPathUtils.java
@@ -35,60 +35,57 @@ import lombok.extern.slf4j.Slf4j;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class DirectoryPathUtils {
     private static final String FORWARDSLASH = "/";
-    private static final String ALL_PERMISSIONS_STRING = "rwxrwxrwx";
+    private static final String ALL_PERMISSIONS_STRING = "rwxrw-rw-";
 
     /**
-     * If adjustable directory has absolute path, checks, that it begins with gridEngineFolder and exists, creates if
+     * If adjustable directory has absolute path, checks, that it begins with rootFolder and exists, creates if
      * needed.
-     * If adjustable directory has relative path, adds gridEngineFolder to its beginning, checks its existence and
+     * If adjustable directory has relative path, adds rootFolder to its beginning, checks its existence and
      * creates, if needed.
      *
-     * @param adjustableFolder Directory, which should be checked for correction path
-     * @param gridEngineFolder Primary working directory from properties
+     * @param nestedFolder Directory, which should be checked for correction path
+     * @param rootFolder Primary working directory from properties
      * @return Adjusted directory path with added primary directory added if needed
      */
-    public static String buildProperDir(final String adjustableFolder, final String gridEngineFolder) {
+    public static String buildProperDir(final String rootFolder, final String nestedFolder) {
         final StringBuilder properDir = new StringBuilder();
-        final File adjustableFolderPath = new File(adjustableFolder);
-        if (adjustableFolderPath.isAbsolute()) {
-            if (!adjustableFolder.startsWith(gridEngineFolder)) {
-                final String errorMessage = "Provided path is absolute, but doesn't begin with Grid Engine folder";
+        final File nestedFolderPath = new File(nestedFolder);
+        if (nestedFolderPath.isAbsolute()) {
+            if (!nestedFolder.startsWith(rootFolder)) {
+                final String errorMessage = "Nested folder path is absolute, but doesn't start with " +
+                        "grid.engine.shared.folder";
                 log.error(errorMessage);
                 throw new IllegalStateException(errorMessage);
             }
-            if (!adjustableFolderPath.exists()) {
+            if (!nestedFolderPath.exists()) {
                 try {
-                    if (adjustableFolderPath.mkdirs()) {
-                        log.info("Directory with path " + adjustableFolderPath + " was created.");
-                        grantAllPermissionsToFolder(adjustableFolderPath);
+                    if (nestedFolderPath.mkdirs()) {
+                        log.info("Directory with path " + nestedFolderPath + " was created.");
+                        grantAllPermissionsToFolder(nestedFolderPath);
                     } else {
-                        final String errorMessage = "Failed to create directory with path " + adjustableFolderPath;
-                        log.error(errorMessage);
-                        throw new IOException(errorMessage);
+                        throw new IOException("Failed to create directory with path " + nestedFolderPath);
                     }
                 } catch (final Exception exception) {
                     log.error(exception.getMessage());
                     exception.printStackTrace();
                 }
             }
-            properDir.append(adjustableFolderPath);
+            properDir.append(nestedFolderPath);
         } else {
-            if (gridEngineFolder.endsWith(FORWARDSLASH)) {
-                properDir.append(gridEngineFolder).append(adjustableFolderPath);
+            if (rootFolder.endsWith(FORWARDSLASH)) {
+                properDir.append(rootFolder).append(nestedFolderPath);
             } else {
-                properDir.append(gridEngineFolder).append(FORWARDSLASH).append(adjustableFolderPath);
+                properDir.append(rootFolder).append(FORWARDSLASH).append(nestedFolderPath);
             }
-            log.info("Provided directory was changed to " + properDir);
+            log.info("Nested folder path was changed to " + properDir);
             final File gridEnginePath = new File(properDir.toString());
             if (!gridEnginePath.exists()) {
                 try {
                     if (gridEnginePath.mkdirs()) {
-                        log.info(gridEnginePath + " Grid Engine folder was created.");
+                        log.info(gridEnginePath + " Grid Shared Folder was created.");
                         grantAllPermissionsToFolder(gridEnginePath);
                     } else {
-                        final String errorMessage = "Failed to create directory with path " + gridEnginePath;
-                        log.error(errorMessage);
-                        throw new IOException(errorMessage);
+                        throw new IOException("Failed to create directory with path " + gridEnginePath);
                     }
                 } catch (final Exception exception) {
                     log.error(exception.getMessage());

--- a/src/main/java/com/epam/grid/engine/provider/utils/DirectoryPathUtils.java
+++ b/src/main/java/com/epam/grid/engine/provider/utils/DirectoryPathUtils.java
@@ -44,9 +44,10 @@ public final class DirectoryPathUtils {
      * creates, if needed.
      *
      * @param path Directory, which should be checked for correction path
-     * @param root   Primary working directory from properties
+     * @param root Primary working directory from properties
      * @return Adjusted directory path with added primary directory added if needed
      */
+
     public static Path resolvePathToAbsolute(final String root, final String path) {
         Path processingPath = Path.of(path);
         if (processingPath.isAbsolute()) {
@@ -64,16 +65,15 @@ public final class DirectoryPathUtils {
 
     private static void checkIfFolderNotExistsAndCreate(final Path folderToCreate) {
         if (!Files.exists(folderToCreate)) {
-            try {
-                if (folderToCreate.toFile().mkdirs()) {
-                    log.info("Directory with path " + folderToCreate + " was created.");
+            if (folderToCreate.toFile().mkdirs()) {
+                log.info("Directory with path " + folderToCreate + " was created.");
+                try {
                     grantAllPermissionsToFolder(folderToCreate);
-                } else {
-                    throw new IllegalArgumentException("Failed to create directory with path " + folderToCreate);
+                } catch (IOException e) {
+                    throw new IllegalArgumentException("Failed to grant permissions to the path " + folderToCreate, e);
                 }
-            } catch (final Exception exception) {
-                throw new IllegalArgumentException("Failed to create a directory by provided path: "
-                        + folderToCreate + ". " + exception.getMessage(), exception);
+            } else {
+                throw new IllegalArgumentException("Failed to create directory with path " + folderToCreate);
             }
         }
     }

--- a/src/main/java/com/epam/grid/engine/provider/utils/DirectoryPathUtils.java
+++ b/src/main/java/com/epam/grid/engine/provider/utils/DirectoryPathUtils.java
@@ -47,7 +47,6 @@ public final class DirectoryPathUtils {
      * @param rootFolder   Primary working directory from properties
      * @return Adjusted directory path with added primary directory added if needed
      */
-    @SuppressWarnings("PMD.PreserveStackTrace")
     public static Path buildProperDir(final String rootFolder, final String nestedFolder) {
         Path processingPath = Path.of(nestedFolder);
         if (processingPath.isAbsolute()) {

--- a/src/main/java/com/epam/grid/engine/provider/utils/DirectoryPathUtils.java
+++ b/src/main/java/com/epam/grid/engine/provider/utils/DirectoryPathUtils.java
@@ -38,24 +38,24 @@ public final class DirectoryPathUtils {
     private static final String ALL_PERMISSIONS_STRING = "rwxrw-rw-";
 
     /**
-     * If nestedFolder directory has absolute path, checks, that it begins with rootFolder and exists, creates if
+     * If path directory has absolute path, checks, that it begins with root and exists, creates if
      * needed.
-     * If nestedFolder directory has relative path, adds rootFolder to its beginning, checks its existence and
+     * If path directory has relative path, adds root to its beginning, checks its existence and
      * creates, if needed.
      *
-     * @param nestedFolder Directory, which should be checked for correction path
-     * @param rootFolder   Primary working directory from properties
+     * @param path Directory, which should be checked for correction path
+     * @param root   Primary working directory from properties
      * @return Adjusted directory path with added primary directory added if needed
      */
-    public static Path buildProperDir(final String rootFolder, final String nestedFolder) {
-        Path processingPath = Path.of(nestedFolder);
+    public static Path resolvePathToAbsolute(final String root, final String path) {
+        Path processingPath = Path.of(path);
         if (processingPath.isAbsolute()) {
-            if (!nestedFolder.startsWith(rootFolder)) {
+            if (!path.startsWith(root)) {
                 throw new IllegalStateException("Nested folder path is absolute, but doesn't start with "
                         + "grid.engine.shared.folder");
             }
         } else {
-            processingPath = Paths.get(rootFolder, nestedFolder);
+            processingPath = Paths.get(root, path);
             log.info("Nested folder path was changed to " + processingPath);
         }
         checkIfFolderNotExistsAndCreate(processingPath);

--- a/src/main/java/com/epam/grid/engine/provider/utils/DirectoryPathUtils.java
+++ b/src/main/java/com/epam/grid/engine/provider/utils/DirectoryPathUtils.java
@@ -24,6 +24,7 @@ import lombok.NoArgsConstructor;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.nio.file.Files;
@@ -38,9 +39,9 @@ public final class DirectoryPathUtils {
     private static final String ALL_PERMISSIONS_STRING = "rwxrw-rw-";
 
     /**
-     * If adjustable directory has absolute path, checks, that it begins with rootFolder and exists, creates if
+     * If nestedFolder directory has absolute path, checks, that it begins with rootFolder and exists, creates if
      * needed.
-     * If adjustable directory has relative path, adds rootFolder to its beginning, checks its existence and
+     * If nestedFolder directory has relative path, adds rootFolder to its beginning, checks its existence and
      * creates, if needed.
      *
      * @param nestedFolder Directory, which should be checked for correction path
@@ -56,21 +57,10 @@ public final class DirectoryPathUtils {
                 throw new IllegalStateException("Nested folder path is absolute, but doesn't start with "
                         + "grid.engine.shared.folder");
             }
-            if (!nestedFolderPath.exists()) {
-                try {
-                    if (nestedFolderPath.mkdirs()) {
-                        log.info("Directory with path " + nestedFolderPath + " was created.");
-                        grantAllPermissionsToFolder(nestedFolderPath);
-                    } else {
-                        throw new IOException("Failed to create directory with path " + nestedFolderPath);
-                    }
-                } catch (final Exception exception) {
-                    throw new IllegalArgumentException("Failed to create a directory by provided path: "
-                            + nestedFolderPath + ". " + exception.getMessage());
-                }
-            }
-            properDir.append(nestedFolderPath);
+            checkIfFolderNotExistsAndCreate(nestedFolderPath);
+            return properDir.append(nestedFolderPath).toString();
         } else {
+            Paths.get(rootFolder).;
             if (rootFolder.endsWith(FORWARDSLASH)) {
                 properDir.append(rootFolder).append(nestedFolderPath);
             } else {
@@ -78,21 +68,26 @@ public final class DirectoryPathUtils {
             }
             log.info("Nested folder path was changed to " + properDir);
             final File gridEnginePath = new File(properDir.toString());
-            if (!gridEnginePath.exists()) {
-                try {
-                    if (gridEnginePath.mkdirs()) {
-                        log.info(gridEnginePath + " Grid Shared Folder was created.");
-                        grantAllPermissionsToFolder(gridEnginePath);
-                    } else {
-                        throw new IOException("Failed to create directory with path " + gridEnginePath);
-                    }
-                } catch (final Exception exception) {
-                    throw new IllegalArgumentException("Failed to create a directory by provided path: "
-                            + gridEnginePath + ". " + exception.getMessage());
+            checkIfFolderNotExistsAndCreate(gridEnginePath);
+            return properDir.toString();
+        }
+    }
+
+    @SuppressWarnings("PMD.PreserveStackTrace")
+    private static void checkIfFolderNotExistsAndCreate(final File folderToCreate) {
+        if (!folderToCreate.exists()) {
+            try {
+                if (folderToCreate.mkdirs()) {
+                    log.info("Directory with path " + folderToCreate + " was created.");
+                    grantAllPermissionsToFolder(folderToCreate);
+                } else {
+                    throw new IOException("Failed to create directory with path " + folderToCreate);
                 }
+            } catch (final Exception exception) {
+                throw new IllegalArgumentException("Failed to create a directory by provided path: "
+                        + folderToCreate + ". " + exception.getMessage());
             }
         }
-        return properDir.toString();
     }
 
     @SuppressWarnings("PMD.PreserveStackTrace")

--- a/src/main/java/com/epam/grid/engine/provider/utils/DirectoryPathUtils.java
+++ b/src/main/java/com/epam/grid/engine/provider/utils/DirectoryPathUtils.java
@@ -1,0 +1,111 @@
+/*
+ *
+ *  * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ *
+ */
+
+package com.epam.grid.engine.provider.utils;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.nio.file.Files;
+import java.util.Set;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class DirectoryPathUtils {
+    private static final String FORWARDSLASH = "/";
+    private static final String ALL_PERMISSIONS_STRING = "rwxrwxrwx";
+
+    /**
+     * If adjustable directory has absolute path, checks, that it begins with gridEngineFolder and exists, creates if
+     * needed.
+     * If adjustable directory has relative path, adds gridEngineFolder to its beginning, checks its existence and
+     * creates, if needed.
+     *
+     * @param adjustableFolder Directory, which should be checked for correction path
+     * @param gridEngineFolder Primary working directory from properties
+     * @return Adjusted directory path with added primary directory added if needed
+     */
+    public static String buildProperDir(final String adjustableFolder, final String gridEngineFolder) {
+        final StringBuilder properDir = new StringBuilder();
+        final File adjustableFolderPath = new File(adjustableFolder);
+        if (adjustableFolderPath.isAbsolute()) {
+            if (!adjustableFolder.startsWith(gridEngineFolder)) {
+                final String errorMessage = "Provided path is absolute, but doesn't begin with Grid Engine folder";
+                log.error(errorMessage);
+                throw new IllegalStateException(errorMessage);
+            }
+            if (!adjustableFolderPath.exists()) {
+                try {
+                    if (adjustableFolderPath.mkdirs()) {
+                        log.info("Directory with path " + adjustableFolderPath + " was created.");
+                        grantAllPermissionsToFolder(adjustableFolderPath);
+                    } else {
+                        final String errorMessage = "Failed to create directory with path " + adjustableFolderPath;
+                        log.error(errorMessage);
+                        throw new IOException(errorMessage);
+                    }
+                } catch (final Exception exception) {
+                    log.error(exception.getMessage());
+                    exception.printStackTrace();
+                }
+            }
+            properDir.append(adjustableFolderPath);
+        } else {
+            if (gridEngineFolder.endsWith(FORWARDSLASH)) {
+                properDir.append(gridEngineFolder).append(adjustableFolderPath);
+            } else {
+                properDir.append(gridEngineFolder).append(FORWARDSLASH).append(adjustableFolderPath);
+            }
+            log.info("Provided directory was changed to " + properDir);
+            final File gridEnginePath = new File(properDir.toString());
+            if (!gridEnginePath.exists()) {
+                try {
+                    if (gridEnginePath.mkdirs()) {
+                        log.info(gridEnginePath + " Grid Engine folder was created.");
+                        grantAllPermissionsToFolder(gridEnginePath);
+                    } else {
+                        final String errorMessage = "Failed to create directory with path " + gridEnginePath;
+                        log.error(errorMessage);
+                        throw new IOException(errorMessage);
+                    }
+                } catch (final Exception exception) {
+                    log.error(exception.getMessage());
+                    exception.printStackTrace();
+                }
+            }
+        }
+        return properDir.toString();
+    }
+
+    private static void grantAllPermissionsToFolder(final File directory) {
+        try {
+            final Set<PosixFilePermission> permissions = PosixFilePermissions.fromString(ALL_PERMISSIONS_STRING);
+            Files.setPosixFilePermissions(directory.toPath(), permissions);
+        } catch (final IOException exception) {
+            log.error("Error while granting permissions to " + directory);
+            exception.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/epam/grid/engine/service/JobOperationProviderService.java
+++ b/src/main/java/com/epam/grid/engine/service/JobOperationProviderService.java
@@ -28,6 +28,7 @@ import com.epam.grid.engine.entity.job.JobLogInfo;
 import com.epam.grid.engine.entity.job.JobOptions;
 import com.epam.grid.engine.provider.job.JobProvider;
 
+import com.epam.grid.engine.provider.utils.DirectoryPathUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -46,6 +47,7 @@ import java.nio.file.Path;
 public class JobOperationProviderService {
 
     private final String logDir;
+    private final String gridEngineFolder;
     private final JobProvider jobProvider;
 
     /**
@@ -57,9 +59,12 @@ public class JobOperationProviderService {
      * @see JobProvider
      */
 
-    public JobOperationProviderService(final JobProvider jobProvider, @Value("${job.log.dir}") final String logDir) {
+    public JobOperationProviderService(final JobProvider jobProvider,
+                                       @Value("${job.log.dir}") final String logDir,
+                                       @Value("${grid.engine.shared.folder}") final String gridEngineFolder) {
         this.jobProvider = jobProvider;
         this.logDir = logDir;
+        this.gridEngineFolder = gridEngineFolder;
     }
 
     /**
@@ -89,6 +94,9 @@ public class JobOperationProviderService {
      * @return Running job.
      */
     public Job runJob(final JobOptions options) {
+        if (options.getWorkingDir() != null) {
+            options.setWorkingDir(DirectoryPathUtils.buildProperDir(options.getWorkingDir(), gridEngineFolder));
+        }
         return jobProvider.runJob(options);
     }
 

--- a/src/main/java/com/epam/grid/engine/service/JobOperationProviderService.java
+++ b/src/main/java/com/epam/grid/engine/service/JobOperationProviderService.java
@@ -37,6 +37,7 @@ import javax.annotation.PostConstruct;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 
 /**
  * This class defines operations for processing information from the user
@@ -94,15 +95,15 @@ public class JobOperationProviderService {
      * @return Running job.
      */
     public Job runJob(final JobOptions options) {
-        final String workingDir = options.getWorkingDir();
-        if (workingDir != null) {
-            final String properDir = DirectoryPathUtils.buildProperDir(gridSharedFolder, options.getWorkingDir())
+        Optional.ofNullable(options.getWorkingDir()).ifPresent(workingDir -> {
+            final String absolutePath = DirectoryPathUtils
+                    .resolvePathToAbsolute(gridSharedFolder, workingDir)
                     .toString();
-            if (!workingDir.equals(properDir)) {
-                options.setWorkingDir(properDir);
-                log.info("Working directory was changed from " + workingDir + " to " + properDir);
+            if (!workingDir.equals(absolutePath)) {
+                options.setWorkingDir(absolutePath);
+                log.info("Working directory was changed from " + workingDir + " to " + absolutePath);
             }
-        }
+        });
         return jobProvider.runJob(options);
     }
 

--- a/src/main/java/com/epam/grid/engine/service/JobOperationProviderService.java
+++ b/src/main/java/com/epam/grid/engine/service/JobOperationProviderService.java
@@ -54,17 +54,20 @@ public class JobOperationProviderService {
     /**
      * Constructor, sets created jobProvider bean to the class field and the path to job log.
      *
-     * @param jobProvider created JobProvider
-     * @param logDir      the path to the directory where all log files will be stored
-     *                    occurred when processing the job
+     * @param jobProvider      created JobProvider
+     * @param logDir           the path to the directory where all log files will be stored
+     *                         occurred when processing the job
+     * @param gridSharedFolder the path to the primary directory from properties, where log and working directories
+     *                         should be stored
      * @see JobProvider
      */
 
     public JobOperationProviderService(final JobProvider jobProvider,
                                        @Value("${job.log.dir}") final String logDir,
-                                       @Value("${grid.engine.shared.folder}") final String gridSharedFolder) {
+                                       @Value("${grid.engine.shared.folder}")
+                                       final String gridSharedFolder) {
         this.jobProvider = jobProvider;
-        this.logDir = logDir;
+        this.logDir = DirectoryPathUtils.resolvePathToAbsolute(gridSharedFolder, logDir).toString();
         this.gridSharedFolder = gridSharedFolder;
     }
 
@@ -96,12 +99,12 @@ public class JobOperationProviderService {
      */
     public Job runJob(final JobOptions options) {
         Optional.ofNullable(options.getWorkingDir()).ifPresent(workingDir -> {
-            final String absolutePath = DirectoryPathUtils
+            final String workingDirAbsolutePath = DirectoryPathUtils
                     .resolvePathToAbsolute(gridSharedFolder, workingDir)
                     .toString();
-            if (!workingDir.equals(absolutePath)) {
-                options.setWorkingDir(absolutePath);
-                log.info("Working directory was changed from " + workingDir + " to " + absolutePath);
+            if (!workingDir.equals(workingDirAbsolutePath)) {
+                options.setWorkingDir(workingDirAbsolutePath);
+                log.info("Working directory was changed from " + workingDir + " to " + workingDirAbsolutePath);
             }
         });
         return jobProvider.runJob(options);

--- a/src/main/java/com/epam/grid/engine/service/JobOperationProviderService.java
+++ b/src/main/java/com/epam/grid/engine/service/JobOperationProviderService.java
@@ -47,7 +47,7 @@ import java.nio.file.Path;
 public class JobOperationProviderService {
 
     private final String logDir;
-    private final String gridEngineFolder;
+    private final String gridSharedFolder;
     private final JobProvider jobProvider;
 
     /**
@@ -61,10 +61,10 @@ public class JobOperationProviderService {
 
     public JobOperationProviderService(final JobProvider jobProvider,
                                        @Value("${job.log.dir}") final String logDir,
-                                       @Value("${grid.engine.shared.folder}") final String gridEngineFolder) {
+                                       @Value("${grid.engine.shared.folder}") final String gridSharedFolder) {
         this.jobProvider = jobProvider;
         this.logDir = logDir;
-        this.gridEngineFolder = gridEngineFolder;
+        this.gridSharedFolder = gridSharedFolder;
     }
 
     /**
@@ -95,7 +95,7 @@ public class JobOperationProviderService {
      */
     public Job runJob(final JobOptions options) {
         if (options.getWorkingDir() != null) {
-            options.setWorkingDir(DirectoryPathUtils.buildProperDir(options.getWorkingDir(), gridEngineFolder));
+            options.setWorkingDir(DirectoryPathUtils.buildProperDir(options.getWorkingDir(), gridSharedFolder));
         }
         return jobProvider.runJob(options);
     }

--- a/src/main/java/com/epam/grid/engine/service/JobOperationProviderService.java
+++ b/src/main/java/com/epam/grid/engine/service/JobOperationProviderService.java
@@ -94,8 +94,14 @@ public class JobOperationProviderService {
      * @return Running job.
      */
     public Job runJob(final JobOptions options) {
-        if (options.getWorkingDir() != null) {
-            options.setWorkingDir(DirectoryPathUtils.buildProperDir(options.getWorkingDir(), gridSharedFolder));
+        final String workingDir = options.getWorkingDir();
+        if (workingDir != null) {
+            final String properDir = DirectoryPathUtils.buildProperDir(gridSharedFolder, options.getWorkingDir())
+                    .toString();
+            if (!workingDir.equals(properDir)) {
+                options.setWorkingDir(properDir);
+                log.info("Working directory was changed from " + workingDir + " to " + properDir);
+            }
         }
         return jobProvider.runJob(options);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,6 +25,7 @@ command.template.path=templates/
 job.log.dir=${GE_JOB_LOGS:logs}/
 api.log.path=${GE_API_LOGS:logs}/
 api.log.keep.days=7
+grid.engine.shared.folder=/data/
 
 #SGE specific properties
 sge.qmaster.port=6444

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,7 +25,7 @@ command.template.path=templates/
 job.log.dir=${GE_JOB_LOGS:logs}/
 api.log.path=${GE_API_LOGS:logs}/
 api.log.keep.days=7
-grid.engine.shared.folder=${GE_API_LOGS:/data/}
+grid.engine.shared.folder=${GRID_SHARED_FOLDER:/mnt/grid-engine-api/}
 
 #SGE specific properties
 sge.qmaster.port=6444

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,7 +25,7 @@ command.template.path=templates/
 job.log.dir=${GE_JOB_LOGS:logs}/
 api.log.path=${GE_API_LOGS:logs}/
 api.log.keep.days=7
-grid.engine.shared.folder=/data/
+grid.engine.shared.folder=${GE_API_LOGS:/data/}
 
 #SGE specific properties
 sge.qmaster.port=6444


### PR DESCRIPTION
Grid engine api uses relative paths to configure job log directory #17

New property grid.engine.shared.folder was added, which can be used during defining log folder and working dir.
If log directory or working dir have absolute path, they should begin with value from shared folder. If their paths are relative, value from shared folder will be added to the beginning of the path. If these folders don't exists, they will be created