### PR TITLE
[Slurm] Run slurm job with parrallel execution configuration epam#14

### DIFF
--- a/src/main/java/com/epam/grid/engine/entity/job/JobOptions.java
+++ b/src/main/java/com/epam/grid/engine/entity/job/JobOptions.java
@@ -76,4 +76,8 @@ public class JobOptions {
      * List of arguments for the command being processed.
      */
     private List<String> arguments;
+    /**
+     * Specific slurm parallel environment settings.
+     */
+    private ParallelExecutionOptions parallelExecutionOptions;
 }

--- a/src/main/java/com/epam/grid/engine/entity/job/ParallelExecutionOptions.java
+++ b/src/main/java/com/epam/grid/engine/entity/job/ParallelExecutionOptions.java
@@ -1,0 +1,51 @@
+/*
+ *
+ *  * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ *
+ */
+
+package com.epam.grid.engine.entity.job;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * This class is used to assign parallel environment options. Can be used only in SLURM.
+ */
+@Value
+@Builder
+public class ParallelExecutionOptions {
+    /**
+     * Number of tasks to be created for the job.
+     */
+    int numTasks;
+    /**
+     * Minimum/maximum number of nodes allocated to the job.
+     */
+    int nodes;
+    /**
+     * Number of CPUs allocated per task.
+     */
+    int cpusPerTask;
+    /**
+     * Maximum number of tasks per allocated node.
+     */
+    int numTasksPerNode;
+    /**
+     * Prevents sharing of allocated nodes with other jobs. Suballocates CPUs to job steps.
+     */
+    boolean exclusive;
+}

--- a/src/main/java/com/epam/grid/engine/provider/job/sge/SgeJobProvider.java
+++ b/src/main/java/com/epam/grid/engine/provider/job/sge/SgeJobProvider.java
@@ -365,6 +365,10 @@ public class SgeJobProvider implements JobProvider {
         if (!checkParallelEnvOptions(options.getParallelEnvOptions())) {
             throw new GridEngineException(HttpStatus.BAD_REQUEST, "Invalid PE specification!");
         }
+        if (options.getParallelExecutionOptions() != null) {
+            throw new UnsupportedOperationException("ParallelExecutionOptions can be used only for SLURM grid engine. "
+                    + "For SGE engine please use ParallelEnvOptions");
+        }
     }
 
     private boolean checkParallelEnvOptions(final ParallelEnvOptions options) {

--- a/src/main/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProvider.java
+++ b/src/main/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProvider.java
@@ -121,8 +121,7 @@ public class SlurmJobProvider implements JobProvider {
                             final SimpleCmdExecutor simpleCmdExecutor,
                             final GridEngineCommandCompiler commandCompiler,
                             @Value("${slurm.job.output-fields-count:52}") final int fieldsCount,
-                            @Value("${SLURM_JOB_NOT_FOUND_MESSAGE:slurm_load_jobs error: Invalid job id specified}")
-                            final String jobIdNotFoundMessage,
+                            @Value("${SLURM_JOB_NOT_FOUND_MESSAGE:slurm_load_jobs error: Invalid job id specified}") final String jobIdNotFoundMessage,
                             @Value("${job.log.dir}") final String logDir,
                             @Value("${grid.engine.shared.folder}") final String gridSharedFolder) {
         this.jobMapper = jobMapper;
@@ -251,10 +250,11 @@ public class SlurmJobProvider implements JobProvider {
             throw new UnsupportedOperationException("Unsupported option was specified, for SLURM engine please "
                     + "use ParallelExecutionOptions");
         }
-        if (isNotPositive(options.getParallelExecutionOptions().getNumTasks())
-                || isNotPositive(options.getParallelExecutionOptions().getNodes())
-                || isNotPositive(options.getParallelExecutionOptions().getCpusPerTask())
-                || isNotPositive(options.getParallelExecutionOptions().getNumTasksPerNode())) {
+        if (options.getParallelExecutionOptions() != null &&
+                (isNotPositive(options.getParallelExecutionOptions().getNumTasks())
+                        || isNotPositive(options.getParallelExecutionOptions().getNodes())
+                        || isNotPositive(options.getParallelExecutionOptions().getCpusPerTask())
+                        || isNotPositive(options.getParallelExecutionOptions().getNumTasksPerNode()))) {
             throw new UnsupportedOperationException("All Parallel execution options except Exclusive should be "
                     + "greater than 0!");
         }

--- a/src/main/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProvider.java
+++ b/src/main/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProvider.java
@@ -244,10 +244,19 @@ public class SlurmJobProvider implements JobProvider {
             throw new GridEngineException(HttpStatus.BAD_REQUEST, "Command should be specified!");
         }
         if (options.getPriority() != null && (options.getPriority() < 0 || options.getPriority() > MAX_SENT_PRIORITY)) {
-            throw new GridEngineException(HttpStatus.BAD_REQUEST, "Priority should be between 0 and 4_294_967_294");
+            throw new GridEngineException(HttpStatus.BAD_REQUEST, "Priority should be between 0 and "
+                    + MAX_SENT_PRIORITY);
         }
         if (options.getParallelEnvOptions() != null) {
-            throw new UnsupportedOperationException("Parallel environment variables are not supported yet!");
+            throw new UnsupportedOperationException("Unsupported option was specified, for SLURM engine please "
+                    + "use ParallelExecutionOptions");
+        }
+        if (isNotPositive(options.getParallelExecutionOptions().getNumTasks())
+                || isNotPositive(options.getParallelExecutionOptions().getNodes())
+                || isNotPositive(options.getParallelExecutionOptions().getCpusPerTask())
+                || isNotPositive(options.getParallelExecutionOptions().getNumTasksPerNode())) {
+            throw new UnsupportedOperationException("All Parallel execution options except Exclusive should be "
+                    + "greater than 0!");
         }
     }
 
@@ -332,5 +341,9 @@ public class SlurmJobProvider implements JobProvider {
                 .findFirst()
                 .orElseThrow(() -> new GridEngineException(HttpStatus.NOT_FOUND,
                         String.format("Id specified in %d for job removal not found!", id)));
+    }
+
+    private boolean isNotPositive(final int intToCheck) {
+        return intToCheck < 1;
     }
 }

--- a/src/main/java/com/epam/grid/engine/provider/parallelenv/sge/SgeParallelEnvProvider.java
+++ b/src/main/java/com/epam/grid/engine/provider/parallelenv/sge/SgeParallelEnvProvider.java
@@ -36,6 +36,7 @@ import com.epam.grid.engine.provider.utils.CommandsUtils;
 import com.epam.grid.engine.provider.utils.sge.common.SgeOutputParsingUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
@@ -62,6 +63,7 @@ import static com.epam.grid.engine.provider.utils.sge.common.SgeEntitiesRegistra
  */
 @Slf4j
 @Service
+@ConditionalOnProperty(name = "grid.engine.type", havingValue = "SGE")
 public class SgeParallelEnvProvider implements ParallelEnvProvider {
 
     private static final String SPECIFY_REQUEST = "Name of PE should be specified!";

--- a/src/main/java/com/epam/grid/engine/provider/parallelenv/slurm/SlurmParallelEnvProvider.java
+++ b/src/main/java/com/epam/grid/engine/provider/parallelenv/slurm/SlurmParallelEnvProvider.java
@@ -1,0 +1,68 @@
+/*
+ *
+ *  * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ *
+ */
+
+package com.epam.grid.engine.provider.parallelenv.slurm;
+
+import com.epam.grid.engine.entity.EngineType;
+import com.epam.grid.engine.entity.ParallelEnvFilter;
+import com.epam.grid.engine.entity.parallelenv.ParallelEnv;
+import com.epam.grid.engine.entity.parallelenv.PeRegistrationVO;
+import com.epam.grid.engine.provider.parallelenv.ParallelEnvProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * This is the implementation of the PE provider for SLURM. This class always returns an exception, as user should use
+ * ParallelExecutionOptions for SLURM.
+ */
+@Service
+@ConditionalOnProperty(name = "grid.engine.type", havingValue = "SLURM")
+public class SlurmParallelEnvProvider implements ParallelEnvProvider {
+    @Override
+    public List<ParallelEnv> listParallelEnv(final ParallelEnvFilter parallelEnvFilter) {
+        throw new UnsupportedOperationException("Parallel environment provider cannot be used in SLURM engine. To set "
+                + "parallel environment options please use ParallelExecutionOptions");
+    }
+
+    @Override
+    public ParallelEnv getParallelEnv(final String peName) {
+        throw new UnsupportedOperationException("Parallel environment provider cannot be used in SLURM engine. To set "
+                + "parallel environment options please use ParallelExecutionOptions");
+    }
+
+    @Override
+    public ParallelEnv deleteParallelEnv(final String parallelEnvName) {
+        throw new UnsupportedOperationException("Parallel environment provider cannot be used in SLURM engine. To set "
+                + "parallel environment options please use ParallelExecutionOptions");
+    }
+
+    @Override
+    public ParallelEnv registerParallelEnv(final PeRegistrationVO registrationRequest) {
+        throw new UnsupportedOperationException("Parallel environment provider cannot be used in SLURM engine. To set "
+                + "parallel environment options please use ParallelExecutionOptions");
+    }
+
+    @Override
+    public EngineType getProviderType() {
+        throw new UnsupportedOperationException("Parallel environment provider cannot be used in SLURM engine. To set "
+                + "parallel environment options please use ParallelExecutionOptions");
+    }
+}

--- a/src/main/resources/templates/slurm/command/sbatch
+++ b/src/main/resources/templates/slurm/command/sbatch
@@ -28,6 +28,15 @@ sbatch --export
 [# th:if="${options.workingDir != null}"]
     --chdir=[(${options.workingDir})]
 [/]
+[# th:if="${options.ParallelExecutionOptions != null}"]
+    --ntasks=[(${options.ParallelExecutionOptions.numTasks})]
+    --nodes=[(${options.ParallelExecutionOptions.nodes})]
+    --cpus-per-task=[(${options.ParallelExecutionOptions.cpusPerTask})]
+    --ntasks-per-node=[(${options.ParallelExecutionOptions.numTasksPerNode})]
+    [# th:if="${options.ParallelExecutionOptions.exclusive}"]
+        --exclusive
+    [/]
+[/]
 [# th:if="${options.canBeBinary}"]
     "--wrap=[(${binaryCommand})]"
 [/]

--- a/src/test/java/com/epam/grid/engine/provider/job/sge/SgeJobProviderTest.java
+++ b/src/test/java/com/epam/grid/engine/provider/job/sge/SgeJobProviderTest.java
@@ -33,6 +33,7 @@ import com.epam.grid.engine.entity.job.JobLogInfo;
 import com.epam.grid.engine.entity.job.JobOptions;
 import com.epam.grid.engine.entity.job.JobState;
 import com.epam.grid.engine.entity.job.ParallelEnvOptions;
+import com.epam.grid.engine.entity.job.ParallelExecutionOptions;
 import com.epam.grid.engine.exception.GridEngineException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
@@ -419,6 +420,17 @@ public class SgeJobProviderTest {
     public void shouldThrowsExceptionBecauseNoCommand() {
         final JobOptions jobOptions = new JobOptions();
         final Throwable thrown = Assertions.assertThrows(GridEngineException.class, () ->
+                sgeJobProvider.runJob(jobOptions));
+        Assertions.assertNotNull(thrown.getMessage());
+    }
+
+    @Test
+    public void shouldThrowExceptionBecauseParallelExecOptionsAreUsed() {
+        final JobOptions jobOptions = new JobOptions();
+        jobOptions.setCommand(COMMAND_SCRIPT_FILE);
+        jobOptions.setParallelExecutionOptions(ParallelExecutionOptions.builder().numTasks(1).numTasksPerNode(1)
+                .cpusPerTask(1).nodes(1).build());
+        final Throwable thrown = Assertions.assertThrows(UnsupportedOperationException.class, () ->
                 sgeJobProvider.runJob(jobOptions));
         Assertions.assertNotNull(thrown.getMessage());
     }

--- a/src/test/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProviderTest.java
+++ b/src/test/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProviderTest.java
@@ -25,13 +25,13 @@ import com.epam.grid.engine.entity.CommandResult;
 import com.epam.grid.engine.entity.EngineType;
 import com.epam.grid.engine.entity.JobFilter;
 import com.epam.grid.engine.entity.Listing;
-import com.epam.grid.engine.entity.job.Job;
-import com.epam.grid.engine.entity.job.JobState;
-import com.epam.grid.engine.entity.job.JobOptions;
-import com.epam.grid.engine.entity.job.ParallelEnvOptions;
-import com.epam.grid.engine.entity.job.ParallelExecutionOptions;
 import com.epam.grid.engine.entity.job.DeleteJobFilter;
 import com.epam.grid.engine.entity.job.DeletedJobInfo;
+import com.epam.grid.engine.entity.job.Job;
+import com.epam.grid.engine.entity.job.JobOptions;
+import com.epam.grid.engine.entity.job.JobState;
+import com.epam.grid.engine.entity.job.ParallelEnvOptions;
+import com.epam.grid.engine.entity.job.ParallelExecutionOptions;
 import com.epam.grid.engine.exception.GridEngineException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -163,7 +163,7 @@ public class SlurmJobProviderTest {
                     String.format(ERROR_DELETING_STRING_TEMPLATE, SOME_CORRECT_JOB_ID_STRING),
                     TERMINATING_JOB_PREFIX + SECOND_CORRECT_JOB_ID);
 
-    private static final String slurmJobWithParallelEnvOpts = "ParallelExecutionOptions(numTasks=4, nodes=2, "
+    private static final String SLURM_JOB_WITH_PARALLEL_ENV_OPTS = "ParallelExecutionOptions(numTasks=4, nodes=2, "
             + "cpusPerTask=4, numTasksPerNode=2, exclusive=true)";
 
     @Autowired
@@ -405,7 +405,6 @@ public class SlurmJobProviderTest {
         Assertions.assertEquals(binaryContextArgument, contextCaptor.getValue().getVariable(BINARY_COMMAND));
     }
 
-
     @ParameterizedTest
     @MethodSource("provideInvalidJobOptions")
     public void shouldThrowWhenPassedIllegalJobOptionsToJobSubmitting(final JobOptions jobOptions) {
@@ -477,15 +476,15 @@ public class SlurmJobProviderTest {
     @Test
     public void shouldReturnCorrectSetParallelExecutionOptions() {
         final JobOptions testJobOptions = JobOptions.builder()
-            .parallelExecutionOptions(ParallelExecutionOptions.builder()
-                .numTasks(4)
-                .nodes(2)
-                .cpusPerTask(4)
-                .numTasksPerNode(2)
-                .exclusive(true)
-                .build())
-            .command(JOB_NAME1)
-            .build();
+                .parallelExecutionOptions(ParallelExecutionOptions.builder()
+                        .numTasks(4)
+                        .nodes(2)
+                        .cpusPerTask(4)
+                        .numTasksPerNode(2)
+                        .exclusive(true)
+                        .build())
+                .command(JOB_NAME1)
+                .build();
 
         final CommandResult commandResult = new CommandResult(List.of(SOME_JOB_IS_SUBMITTED), 0, EMPTY_LIST);
         doReturn(commandResult).when(mockCmdExecutor).execute(Mockito.any());
@@ -496,7 +495,7 @@ public class SlurmJobProviderTest {
         Mockito.verify(mockCommandCompiler).compileCommand(Mockito.any(), Mockito.any(), contextCaptor.capture());
 
         assertThat(contextCaptor.getValue().getVariable("options").toString(),
-                containsString(slurmJobWithParallelEnvOpts));
+                containsString(SLURM_JOB_WITH_PARALLEL_ENV_OPTS));
     }
 
     @Test
@@ -544,11 +543,11 @@ public class SlurmJobProviderTest {
 
     static Stream<Arguments> provideValidNameCasesForRequestsToDeleteJob() {
         return Stream.of(
-            Arguments.of(SLURM_USER, null,
-                new String[]{SCANCEL_COMMAND, VERBOSE_KEY, SOME_CORRECT_JOB_ID_STRING}),
-            Arguments.of(SOME_USER_NAME, SOME_USER_NAME,
-                new String[]{SCANCEL_COMMAND, VERBOSE_KEY, OWNER_FILTRATION_KEY, SOME_USER_NAME,
-                    SOME_CORRECT_JOB_ID_STRING})
+                Arguments.of(SLURM_USER, null,
+                        new String[]{SCANCEL_COMMAND, VERBOSE_KEY, SOME_CORRECT_JOB_ID_STRING}),
+                Arguments.of(SOME_USER_NAME, SOME_USER_NAME,
+                        new String[]{SCANCEL_COMMAND, VERBOSE_KEY, OWNER_FILTRATION_KEY,
+                                     SOME_USER_NAME, SOME_CORRECT_JOB_ID_STRING})
         );
     }
 

--- a/src/test/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProviderTest.java
+++ b/src/test/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProviderTest.java
@@ -448,11 +448,11 @@ public class SlurmJobProviderTest {
 
     static Stream<Arguments> provideCorrectSbatchCommands() {
         return Stream.of(
-                        new String[]{SBATCH_COMMAND, "--export=", ENV_VAR_COMMAND_ARG, JOB_NAME1},
-                        new String[]{SBATCH_COMMAND, "--priority=", JOB_PRIORITY4, JOB_NAME1},
-                        new String[]{SBATCH_COMMAND, "-J", JOB_NAME3, JOB_NAME1},
-                        new String[]{SBATCH_COMMAND, "--partition=", JOB_PARTITION, JOB_NAME1},
-                        new String[]{SBATCH_COMMAND, "-D", JOB_WORK_DIR, JOB_NAME1})
+                    new String[]{SBATCH_COMMAND, "--export=", ENV_VAR_COMMAND_ARG, JOB_NAME1},
+                    new String[]{SBATCH_COMMAND, "--priority=", JOB_PRIORITY4, JOB_NAME1},
+                    new String[]{SBATCH_COMMAND, "-J", JOB_NAME3, JOB_NAME1},
+                    new String[]{SBATCH_COMMAND, "--partition=", JOB_PARTITION, JOB_NAME1},
+                    new String[]{SBATCH_COMMAND, "-D", JOB_WORK_DIR, JOB_NAME1})
                 .map((t) -> (Object) t)
                 .map(Arguments::of);
     }
@@ -544,10 +544,10 @@ public class SlurmJobProviderTest {
     static Stream<Arguments> provideValidNameCasesForRequestsToDeleteJob() {
         return Stream.of(
                 Arguments.of(SLURM_USER, null,
-                        new String[]{SCANCEL_COMMAND, VERBOSE_KEY, SOME_CORRECT_JOB_ID_STRING}),
+                    new String[] {SCANCEL_COMMAND, VERBOSE_KEY, SOME_CORRECT_JOB_ID_STRING}),
                 Arguments.of(SOME_USER_NAME, SOME_USER_NAME,
-                        new String[]{SCANCEL_COMMAND, VERBOSE_KEY, OWNER_FILTRATION_KEY,
-                                     SOME_USER_NAME, SOME_CORRECT_JOB_ID_STRING})
+                    new String[] {SCANCEL_COMMAND, VERBOSE_KEY, OWNER_FILTRATION_KEY,
+                                  SOME_USER_NAME, SOME_CORRECT_JOB_ID_STRING})
         );
     }
 


### PR DESCRIPTION
[Slurm] Run slurm job with parrallel execution configuration #14
New functionality to set parallel environment options in slurm was added.
New class ParallelExecutionOptions was added as an additional optional was added with the following fields:
int nTasks
int nodes
int cpusPerTask
int nTasksPerNode
boolean exclusive

Parallel environment options are still cannot be used in SLURM - an exception will be thrown
Parallel execution options cannot be used in SGE - an exeption will be thrown