### PR TITLE
Ability to use test properties to run tests

### DIFF
--- a/src/main/java/com/epam/grid/engine/controller/AbstractRestController.java
+++ b/src/main/java/com/epam/grid/engine/controller/AbstractRestController.java
@@ -29,7 +29,7 @@ import java.io.InputStream;
 
 public abstract class AbstractRestController {
     /**
-     * Writes passed content to {@code HttpServletResponse} to allow it's downloading from the client.
+     * Writes passed content to {@link HttpServletResponse} to allow it's downloading from the client.
      *
      * @param response The object to write data
      * @param stream   The file data stream

--- a/src/main/java/com/epam/grid/engine/controller/queue/QueueOperationController.java
+++ b/src/main/java/com/epam/grid/engine/controller/queue/QueueOperationController.java
@@ -133,11 +133,10 @@ public class QueueOperationController {
     }
 
     /**
-     * Registers a {@code queue} with specified in the {@link QueueVO} properties.
+     * Registers a queue with specified in the {@link QueueVO} properties.
      *
      * @param registrationRequest the properties of the queue to be registered
-     * @return the registered {@code queue}
-     * @see Queue
+     * @return the registered {@link Queue}
      */
     @PostMapping
     @ResponseStatus(HttpStatus.OK)
@@ -157,11 +156,10 @@ public class QueueOperationController {
     }
 
     /**
-     * Updates a {@code queue} with specified in the {@link QueueVO} properties.
+     * Updates a queue with specified in the {@link QueueVO} properties.
      *
      * @param updateRequest the properties of the queue to be updated
-     * @return the updated {@code queue}
-     * @see Queue
+     * @return the updated {@link Queue}
      */
     @PutMapping
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/com/epam/grid/engine/provider/queue/QueueProvider.java
+++ b/src/main/java/com/epam/grid/engine/provider/queue/QueueProvider.java
@@ -55,18 +55,18 @@ public interface QueueProvider extends CommandTypeAware {
     Queue deleteQueues(String queueName);
 
     /**
-     * Registers a {@code queue} with specified properties in grid engine system.
+     * Registers a queue with specified properties in grid engine system.
      *
      * @param registrationRequest the properties of the queue to be registered
-     * @return the registered {@code queue}
+     * @return the registered {@link Queue}
      */
     Queue registerQueue(QueueVO registrationRequest);
 
     /**
-     * Updates a {@code queue} with specified properties in grid engine system.
+     * Updates a queue with specified properties in grid engine system.
      *
      * @param updateRequest the properties of the queue to be updated
-     * @return the updated {@code queue}
+     * @return the updated {@link Queue}
      */
     Queue updateQueue(QueueVO updateRequest);
 }

--- a/src/main/java/com/epam/grid/engine/provider/queue/sge/SgeQueueProvider.java
+++ b/src/main/java/com/epam/grid/engine/provider/queue/sge/SgeQueueProvider.java
@@ -156,11 +156,10 @@ public class SgeQueueProvider implements QueueProvider {
     }
 
     /**
-     * Registers a {@code queue} matching the requested description in the Sun Grid Engine queuing system.
+     * Registers a queue matching the requested description in the Sun Grid Engine queuing system.
      *
      * @param registrationRequest the description of the queue to be registered
-     * @return the registered {@code queue}
-     * @see Queue
+     * @return the registered {@link Queue}
      */
     @Override
     public Queue registerQueue(final QueueVO registrationRequest) {
@@ -193,11 +192,10 @@ public class SgeQueueProvider implements QueueProvider {
     }
 
     /**
-     * Updates a {@code queue} matching the requested description in the Sun Grid Engine queuing system.
+     * Updates a queue matching the requested description in the Sun Grid Engine queuing system.
      *
      * @param updateRequest the description of the queue to be updated
-     * @return the updated {@code queue}
-     * @see Queue
+     * @return the updated {@link Queue}
      */
     @Override
     public Queue updateQueue(final QueueVO updateRequest) {

--- a/src/main/java/com/epam/grid/engine/provider/utils/sge/usage/SgeAccountingDataParser.java
+++ b/src/main/java/com/epam/grid/engine/provider/utils/sge/usage/SgeAccountingDataParser.java
@@ -44,11 +44,10 @@ public abstract class SgeAccountingDataParser {
     private static final String SGE_OUTPUT_HEADER = "Total System Usage";
 
     /**
-     * This method parses SGE usage summary information and converts it into a {@code UsageReport} object.
+     * This method parses SGE usage summary information and converts it into a {@link UsageReport} object.
      *
      * @param stdOut - a List containing stdOut of SGE CommandResult
      * @return the report object containing completely parsed usage summary information
-     * @see UsageReport
      */
     public abstract UsageReport parseAccountingDataFromStdOut(final List<String> stdOut);
 

--- a/src/main/java/com/epam/grid/engine/service/QueueOperationProviderService.java
+++ b/src/main/java/com/epam/grid/engine/service/QueueOperationProviderService.java
@@ -69,10 +69,10 @@ public class QueueOperationProviderService {
     }
 
     /**
-     * Registers a {@code queue} with specified properties in preassigned grid engine system.
+     * Registers a queue with specified properties in preassigned grid engine system.
      *
      * @param registrationRequest the properties of the queue to be registered
-     * @return the registered {@code queue}
+     * @return the registered {@link Queue}
      */
     public Queue registerQueue(final QueueVO registrationRequest) {
         return queueProvider.registerQueue(registrationRequest);
@@ -80,10 +80,10 @@ public class QueueOperationProviderService {
 
 
     /**
-     * Updates a {@code queue} with specified properties in preassigned grid engine system.
+     * Updates a queue with specified properties in preassigned grid engine system.
      *
      * @param updateRequest the properties of the queue to be updated
-     * @return the updated {@code queue}
+     * @return the updated {@link Queue}
      */
     public Queue updateQueue(final QueueVO updateRequest) {
         return queueProvider.updateQueue(updateRequest);

--- a/src/test/java/com/epam/grid/engine/TestPropertiesWithSgeEngine.java
+++ b/src/test/java/com/epam/grid/engine/TestPropertiesWithSgeEngine.java
@@ -1,0 +1,14 @@
+package com.epam.grid.engine;
+
+import org.springframework.test.context.TestPropertySource;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@TestPropertySource(locations = "classpath:test-application.properties", properties = {"grid.engine.type=SGE"})
+public @interface TestPropertiesWithSgeEngine {
+}

--- a/src/test/java/com/epam/grid/engine/TestPropertiesWithSlurmEngine.java
+++ b/src/test/java/com/epam/grid/engine/TestPropertiesWithSlurmEngine.java
@@ -1,0 +1,14 @@
+package com.epam.grid.engine;
+
+import org.springframework.test.context.TestPropertySource;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@TestPropertySource(locations = "classpath:test-application.properties", properties = {"grid.engine.type=SLURM"})
+public @interface TestPropertiesWithSlurmEngine {
+}

--- a/src/test/java/com/epam/grid/engine/provider/healthcheck/sge/SgeHealthCheckProviderTest.java
+++ b/src/test/java/com/epam/grid/engine/provider/healthcheck/sge/SgeHealthCheckProviderTest.java
@@ -19,6 +19,7 @@
 
 package com.epam.grid.engine.provider.healthcheck.sge;
 
+import com.epam.grid.engine.TestPropertiesWithSgeEngine;
 import com.epam.grid.engine.cmd.SimpleCmdExecutor;
 import com.epam.grid.engine.entity.CommandResult;
 import com.epam.grid.engine.entity.healthcheck.GridEngineStatus;
@@ -42,7 +43,8 @@ import static com.epam.grid.engine.provider.utils.sge.TestSgeConstants.EMPTY_STR
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.doReturn;
 
-@SpringBootTest(properties = {"grid.engine.type=SGE"})
+@SpringBootTest
+@TestPropertiesWithSgeEngine
 public class SgeHealthCheckProviderTest {
 
     private static final String SOME_HOST = "someHost";

--- a/src/test/java/com/epam/grid/engine/provider/healthcheck/slurm/SlurmHealthCheckProviderTest.java
+++ b/src/test/java/com/epam/grid/engine/provider/healthcheck/slurm/SlurmHealthCheckProviderTest.java
@@ -19,6 +19,7 @@
 
 package com.epam.grid.engine.provider.healthcheck.slurm;
 
+import com.epam.grid.engine.TestPropertiesWithSlurmEngine;
 import com.epam.grid.engine.cmd.SimpleCmdExecutor;
 import com.epam.grid.engine.entity.CommandResult;
 import com.epam.grid.engine.entity.healthcheck.GridEngineStatus;
@@ -42,7 +43,8 @@ import static com.epam.grid.engine.utils.TextConstants.NEW_LINE_DELIMITER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.doReturn;
 
-@SpringBootTest(properties = {"grid.engine.type=SLURM"})
+@SpringBootTest
+@TestPropertiesWithSlurmEngine
 public class SlurmHealthCheckProviderTest {
 
     private static final String NOT_PROVIDED_OUT = "some key    = some values" + NEW_LINE_DELIMITER

--- a/src/test/java/com/epam/grid/engine/provider/host/sge/SgeHostProviderTest.java
+++ b/src/test/java/com/epam/grid/engine/provider/host/sge/SgeHostProviderTest.java
@@ -19,6 +19,7 @@
 
 package com.epam.grid.engine.provider.host.sge;
 
+import com.epam.grid.engine.TestPropertiesWithSgeEngine;
 import com.epam.grid.engine.cmd.SimpleCmdExecutor;
 import com.epam.grid.engine.entity.CommandResult;
 import com.epam.grid.engine.entity.HostFilter;
@@ -39,7 +40,8 @@ import static com.epam.grid.engine.provider.utils.sge.TestSgeConstants.SINGLETON
 import static com.epam.grid.engine.provider.utils.sge.TestSgeConstants.TYPE_XML;
 import static org.mockito.Mockito.doReturn;
 
-@SpringBootTest(properties = {"grid.engine.type=SGE"})
+@SpringBootTest
+@TestPropertiesWithSgeEngine
 public class SgeHostProviderTest {
 
     private static final String CORRECT_XML = "<?xml version='1.0'?>"

--- a/src/test/java/com/epam/grid/engine/provider/host/slurm/SlurmHostProviderTest.java
+++ b/src/test/java/com/epam/grid/engine/provider/host/slurm/SlurmHostProviderTest.java
@@ -19,6 +19,7 @@
 
 package com.epam.grid.engine.provider.host.slurm;
 
+import com.epam.grid.engine.TestPropertiesWithSlurmEngine;
 import com.epam.grid.engine.cmd.SimpleCmdExecutor;
 import com.epam.grid.engine.entity.CommandResult;
 import com.epam.grid.engine.entity.HostFilter;
@@ -37,7 +38,8 @@ import java.util.List;
 import static com.epam.grid.engine.provider.utils.sge.TestSgeConstants.EMPTY_LIST;
 import static org.mockito.Mockito.doReturn;
 
-@SpringBootTest(properties = {"grid.engine.type=SLURM"})
+@SpringBootTest
+@TestPropertiesWithSlurmEngine
 public class SlurmHostProviderTest {
 
     private static final String WORKER1_OUT = "NodeName=worker1 Arch=x86_64 CoresPerSocket=1  CPUAlloc=0 CPUTot=1 "

--- a/src/test/java/com/epam/grid/engine/provider/hostgroup/sge/SgeHostGroupProviderTest.java
+++ b/src/test/java/com/epam/grid/engine/provider/hostgroup/sge/SgeHostGroupProviderTest.java
@@ -19,6 +19,7 @@
 
 package com.epam.grid.engine.provider.hostgroup.sge;
 
+import com.epam.grid.engine.TestPropertiesWithSgeEngine;
 import com.epam.grid.engine.cmd.SimpleCmdExecutor;
 import com.epam.grid.engine.entity.CommandResult;
 import com.epam.grid.engine.entity.HostGroupFilter;
@@ -36,7 +37,8 @@ import java.util.List;
 import static com.epam.grid.engine.provider.utils.sge.TestSgeConstants.SINGLETON_LIST_WITH_STANDARD_WARN;
 import static org.mockito.Mockito.doReturn;
 
-@SpringBootTest(properties = {"grid.engine.type=SGE"})
+@SpringBootTest
+@TestPropertiesWithSgeEngine
 public class SgeHostGroupProviderTest {
 
     private static final String QCONF_COMMAND = "qconf";

--- a/src/test/java/com/epam/grid/engine/provider/job/sge/SgeJobProviderTest.java
+++ b/src/test/java/com/epam/grid/engine/provider/job/sge/SgeJobProviderTest.java
@@ -19,6 +19,7 @@
 
 package com.epam.grid.engine.provider.job.sge;
 
+import com.epam.grid.engine.TestPropertiesWithSgeEngine;
 import com.epam.grid.engine.cmd.GridEngineCommandCompiler;
 import com.epam.grid.engine.cmd.SimpleCmdExecutor;
 import com.epam.grid.engine.entity.CommandResult;
@@ -53,7 +54,8 @@ import static com.epam.grid.engine.provider.utils.sge.TestSgeConstants.PENDING_S
 import static com.epam.grid.engine.provider.utils.sge.TestSgeConstants.RUNNING_STRING;
 import static com.epam.grid.engine.provider.utils.sge.TestSgeConstants.TYPE_XML;
 
-@SpringBootTest(properties = {"grid.engine.type=SGE"})
+@SpringBootTest
+@TestPropertiesWithSgeEngine
 public class SgeJobProviderTest {
 
     private static final long SOME_JOB_ID_1 = 10;

--- a/src/test/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProviderTest.java
+++ b/src/test/java/com/epam/grid/engine/provider/job/slurm/SlurmJobProviderTest.java
@@ -19,6 +19,7 @@
 
 package com.epam.grid.engine.provider.job.slurm;
 
+import com.epam.grid.engine.TestPropertiesWithSlurmEngine;
 import com.epam.grid.engine.cmd.GridEngineCommandCompiler;
 import com.epam.grid.engine.cmd.SimpleCmdExecutor;
 import com.epam.grid.engine.entity.CommandResult;
@@ -53,7 +54,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
-@SpringBootTest(properties = {"grid.engine.type=SLURM"})
+@SpringBootTest
+@TestPropertiesWithSlurmEngine
 public class SlurmJobProviderTest {
 
     private static final String SLURM_USER = "root";

--- a/src/test/java/com/epam/grid/engine/provider/pe/sge/SgePeProviderTest.java
+++ b/src/test/java/com/epam/grid/engine/provider/pe/sge/SgePeProviderTest.java
@@ -19,9 +19,9 @@
 
 package com.epam.grid.engine.provider.pe.sge;
 
+import com.epam.grid.engine.TestPropertiesWithSgeEngine;
 import com.epam.grid.engine.cmd.SimpleCmdExecutor;
 import com.epam.grid.engine.entity.CommandResult;
-import com.epam.grid.engine.entity.CommandType;
 import com.epam.grid.engine.entity.ParallelEnvFilter;
 import com.epam.grid.engine.entity.parallelenv.AllocationRuleType;
 import com.epam.grid.engine.entity.parallelenv.ParallelEnv;
@@ -52,7 +52,8 @@ import static com.epam.grid.engine.provider.utils.sge.TestSgeConstants.EMPTY_LIS
 import static com.epam.grid.engine.provider.utils.sge.TestSgeConstants.EMPTY_STRING;
 import static org.mockito.Mockito.doReturn;
 
-@SpringBootTest(properties = {"grid.engine.type=SGE"})
+@SpringBootTest
+@TestPropertiesWithSgeEngine
 public class SgePeProviderTest {
 
     private static final List<String> VALID_PE = List.of(

--- a/src/test/java/com/epam/grid/engine/provider/queue/sge/SgeQueueProviderTest.java
+++ b/src/test/java/com/epam/grid/engine/provider/queue/sge/SgeQueueProviderTest.java
@@ -19,6 +19,7 @@
 
 package com.epam.grid.engine.provider.queue.sge;
 
+import com.epam.grid.engine.TestPropertiesWithSgeEngine;
 import com.epam.grid.engine.cmd.SimpleCmdExecutor;
 import com.epam.grid.engine.entity.CommandResult;
 import com.epam.grid.engine.entity.QueueFilter;
@@ -49,7 +50,8 @@ import static com.epam.grid.engine.provider.utils.sge.TestSgeConstants.SINGLETON
 import static com.epam.grid.engine.provider.utils.sge.TestSgeConstants.SPACE;
 import static org.mockito.Mockito.doReturn;
 
-@SpringBootTest(properties = {"grid.engine.type=SGE"})
+@SpringBootTest
+@TestPropertiesWithSgeEngine
 public class SgeQueueProviderTest {
 
     private static final List<String> validQueue = List.of(

--- a/src/test/java/com/epam/grid/engine/provider/usage/sge/SgeUsageProviderTest.java
+++ b/src/test/java/com/epam/grid/engine/provider/usage/sge/SgeUsageProviderTest.java
@@ -19,6 +19,7 @@
 
 package com.epam.grid.engine.provider.usage.sge;
 
+import com.epam.grid.engine.TestPropertiesWithSgeEngine;
 import com.epam.grid.engine.cmd.SimpleCmdExecutor;
 import com.epam.grid.engine.entity.CommandResult;
 import com.epam.grid.engine.entity.usage.UsageReport;
@@ -36,7 +37,8 @@ import static com.epam.grid.engine.provider.utils.sge.TestSgeConstants.EMPTY_LIS
 import static com.epam.grid.engine.provider.utils.sge.TestSgeConstants.SINGLETON_LIST_WITH_STANDARD_WARN;
 import static org.mockito.Mockito.doReturn;
 
-@SpringBootTest(properties = {"grid.engine.type=SGE"})
+@SpringBootTest
+@TestPropertiesWithSgeEngine
 public class SgeUsageProviderTest {
 
     private static final String QACCT_COMMAND = "qacct";

--- a/src/test/java/com/epam/grid/engine/service/HealthCheckProviderServiceTest.java
+++ b/src/test/java/com/epam/grid/engine/service/HealthCheckProviderServiceTest.java
@@ -19,6 +19,7 @@
 
 package com.epam.grid.engine.service;
 
+import com.epam.grid.engine.TestPropertiesWithSgeEngine;
 import com.epam.grid.engine.entity.healthcheck.GridEngineStatus;
 import com.epam.grid.engine.entity.healthcheck.HealthCheckInfo;
 import com.epam.grid.engine.entity.healthcheck.StatusInfo;
@@ -27,7 +28,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.time.LocalDateTime;
 
@@ -35,14 +36,16 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@SpringBootTest(properties = {"grid.engine.type=SGE"})
+@SpringBootTest
+@TestPropertiesWithSgeEngine
 public class HealthCheckProviderServiceTest {
 
     private static final String SOME_INFO = "SomeInfo";
 
     @Autowired
     private HealthCheckProviderService healthCheckProviderService;
-    @SpyBean
+
+    @MockBean
     private HealthCheckProvider healthCheckProvider;
 
     @Test

--- a/src/test/java/com/epam/grid/engine/service/HostGroupOperationProviderServiceTest.java
+++ b/src/test/java/com/epam/grid/engine/service/HostGroupOperationProviderServiceTest.java
@@ -19,6 +19,7 @@
 
 package com.epam.grid.engine.service;
 
+import com.epam.grid.engine.TestPropertiesWithSgeEngine;
 import com.epam.grid.engine.entity.HostGroupFilter;
 import com.epam.grid.engine.entity.hostgroup.HostGroup;
 import com.epam.grid.engine.provider.hostgroup.HostGroupProvider;
@@ -26,7 +27,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.util.Collections;
 import java.util.List;
@@ -35,7 +36,8 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@SpringBootTest(properties = {"grid.engine.type=SGE"})
+@SpringBootTest
+@TestPropertiesWithSgeEngine
 public class HostGroupOperationProviderServiceTest {
 
     private static final String HOST_GROUP_NAME = "@allhosts";
@@ -44,7 +46,7 @@ public class HostGroupOperationProviderServiceTest {
     @Autowired
     private HostGroupOperationProviderService hostGroupOperationProviderService;
 
-    @SpyBean
+    @MockBean
     private HostGroupProvider hostGroupProvider;
 
     @Test

--- a/src/test/java/com/epam/grid/engine/service/HostOperationProviderServiceTest.java
+++ b/src/test/java/com/epam/grid/engine/service/HostOperationProviderServiceTest.java
@@ -19,78 +19,57 @@
 
 package com.epam.grid.engine.service;
 
+import com.epam.grid.engine.TestPropertiesWithSgeEngine;
 import com.epam.grid.engine.entity.HostFilter;
 import com.epam.grid.engine.entity.Listing;
 import com.epam.grid.engine.entity.host.Host;
-import com.epam.grid.engine.provider.host.sge.SgeHostProvider;
+import com.epam.grid.engine.provider.host.HostProvider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 
-@SpringBootTest(properties = {"grid.engine.type=SGE"})
+@SpringBootTest
+@TestPropertiesWithSgeEngine
 public class HostOperationProviderServiceTest {
 
-    private static final String TEST = "test-ip";
-    private static final String TYPE = "lx-amd64";
+    private static final String HOST_NAME = "test-ip";
 
     @Autowired
     HostOperationProviderService hostOperationProviderService;
 
-    @SpyBean
-    SgeHostProvider hostProvider;
+    @MockBean
+    HostProvider hostProvider;
 
     @Test
     public void shouldReturnCorrectResponse() {
-        final Listing<Host> hostListing = listingParser(listParser());
+        final Listing<Host> hostListing = new Listing<>(
+                List.of(Host.builder()
+                    .hostname(HOST_NAME)
+                    .typeOfArchitect("lx-amd64")
+                    .numOfProcessors(2)
+                    .numOfSocket(1)
+                    .numOfCore(1)
+                    .numOfThread(2)
+                    .load(0.0)
+                    .memTotal(3600000000L)
+                    .memUsed(311600000L)
+                    .totalSwapSpace(0.0)
+                    .usedSwapSpace(0.0)
+                    .build()));
+
         final HostFilter hostFilter = new HostFilter();
-        hostFilter.setHosts(Collections.singletonList(TEST));
+        hostFilter.setHosts(List.of(HOST_NAME));
 
         doReturn(hostListing).when(hostProvider).listHosts(hostFilter);
         Assertions.assertEquals(hostListing, hostOperationProviderService.filter(hostFilter));
         Mockito.verify(hostProvider, times(1)).listHosts(hostFilter);
-    }
-
-    private static List<Host> listParser() {
-        return Collections.singletonList(Host.builder()
-                .hostname(TEST)
-                .typeOfArchitect(TYPE)
-                .numOfProcessors(2)
-                .numOfSocket(1)
-                .numOfCore(1)
-                .numOfThread(2)
-                .load(0.0)
-                .memTotal(3600000000L)
-                .memUsed(311600000L)
-                .totalSwapSpace(0.0)
-                .usedSwapSpace(0.0)
-                .build());
-    }
-
-    private static Listing<Host> listingParser(final List<Host> hosts) {
-        return new Listing<>(hosts.stream()
-                .map(host -> Host.builder()
-                        .hostname(host.getHostname())
-                        .typeOfArchitect(host.getTypeOfArchitect())
-                        .numOfProcessors(host.getNumOfProcessors())
-                        .numOfSocket(host.getNumOfSocket())
-                        .numOfCore(host.getNumOfCore())
-                        .numOfThread(host.getNumOfThread())
-                        .load(host.getLoad())
-                        .memTotal(host.getMemTotal())
-                        .memUsed(host.getMemUsed())
-                        .totalSwapSpace(host.getTotalSwapSpace())
-                        .usedSwapSpace(host.getUsedSwapSpace())
-                        .build())
-                .collect(Collectors.toList()));
     }
 }

--- a/src/test/java/com/epam/grid/engine/service/JobOperationProviderServiceTest.java
+++ b/src/test/java/com/epam/grid/engine/service/JobOperationProviderServiceTest.java
@@ -19,6 +19,7 @@
 
 package com.epam.grid.engine.service;
 
+import com.epam.grid.engine.TestPropertiesWithSgeEngine;
 import com.epam.grid.engine.entity.JobFilter;
 import com.epam.grid.engine.entity.Listing;
 import com.epam.grid.engine.entity.job.DeleteJobFilter;
@@ -47,7 +48,8 @@ import java.util.stream.Stream;
 
 import static com.epam.grid.engine.provider.utils.sge.TestSgeConstants.EMPTY_STRING;
 
-@SpringBootTest(properties = {"grid.engine.type=SGE"})
+@SpringBootTest
+@TestPropertiesWithSgeEngine
 public class JobOperationProviderServiceTest {
 
     private static final long SOME_JOB_ID = 7L;
@@ -59,7 +61,6 @@ public class JobOperationProviderServiceTest {
     private static final String DATE = "1986-04-08T12:30:00";
     private static final String PENDING_STATE = "pending";
     private static final String SOME_JOB_LOG_DIRECTORY_PATH = "/mnt/logs";
-
 
     @Autowired
     private JobOperationProviderService jobOperationProviderService;

--- a/src/test/java/com/epam/grid/engine/service/PeOperationProviderServiceTest.java
+++ b/src/test/java/com/epam/grid/engine/service/PeOperationProviderServiceTest.java
@@ -19,6 +19,7 @@
 
 package com.epam.grid.engine.service;
 
+import com.epam.grid.engine.TestPropertiesWithSgeEngine;
 import com.epam.grid.engine.entity.ParallelEnvFilter;
 import com.epam.grid.engine.entity.parallelenv.AllocationRuleType;
 import com.epam.grid.engine.entity.parallelenv.ParallelEnv;
@@ -26,13 +27,13 @@ import com.epam.grid.engine.entity.parallelenv.PeRegistrationVO;
 import com.epam.grid.engine.entity.parallelenv.RuleState;
 import com.epam.grid.engine.entity.parallelenv.UrgencyState;
 import com.epam.grid.engine.entity.parallelenv.UrgencyStateType;
-import com.epam.grid.engine.provider.parallelenv.sge.SgeParallelEnvProvider;
+import com.epam.grid.engine.provider.parallelenv.ParallelEnvProvider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.util.Collections;
 import java.util.List;
@@ -40,7 +41,8 @@ import java.util.List;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 
-@SpringBootTest(properties = {"grid.engine.type=SGE"})
+@SpringBootTest
+@TestPropertiesWithSgeEngine
 public class PeOperationProviderServiceTest {
 
     private static final String FIVE = "5";
@@ -52,8 +54,8 @@ public class PeOperationProviderServiceTest {
     @Autowired
     private ParallelEnvOperationProviderService parallelEnvOperationProviderService;
 
-    @SpyBean
-    private SgeParallelEnvProvider parallelEnvProvider;
+    @MockBean
+    private ParallelEnvProvider parallelEnvProvider;
 
     @Test
     public void shouldReturnCorrectPostResponse() {

--- a/src/test/java/com/epam/grid/engine/service/QueueOperationProviderServiceTest.java
+++ b/src/test/java/com/epam/grid/engine/service/QueueOperationProviderServiceTest.java
@@ -19,16 +19,17 @@
 
 package com.epam.grid.engine.service;
 
+import com.epam.grid.engine.TestPropertiesWithSgeEngine;
 import com.epam.grid.engine.entity.QueueFilter;
 import com.epam.grid.engine.entity.queue.Queue;
 import com.epam.grid.engine.entity.queue.QueueVO;
-import com.epam.grid.engine.provider.queue.sge.SgeQueueProvider;
+import com.epam.grid.engine.provider.queue.QueueProvider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.util.Collections;
 import java.util.List;
@@ -36,7 +37,8 @@ import java.util.List;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 
-@SpringBootTest(properties = {"grid.engine.type=SGE"})
+@SpringBootTest
+@TestPropertiesWithSgeEngine
 public class QueueOperationProviderServiceTest {
 
     private static final String COMMAND_QCONF = "qconf";
@@ -48,8 +50,8 @@ public class QueueOperationProviderServiceTest {
     @Autowired
     QueueOperationProviderService queueOperationProviderService;
 
-    @SpyBean
-    SgeQueueProvider sgeQueueProvider;
+    @MockBean
+    QueueProvider queueProvider;
 
     @Test
     public void shouldReturnCorrectQueue() {
@@ -60,9 +62,9 @@ public class QueueOperationProviderServiceTest {
         final QueueFilter queueFilter = new QueueFilter();
         queueFilter.setQueues(List.of(COMMAND_QCONF, OPTION_SQ, TEST_QUEUE_NAME));
 
-        doReturn(queues).when(sgeQueueProvider).listQueues(queueFilter);
+        doReturn(queues).when(queueProvider).listQueues(queueFilter);
         Assertions.assertEquals(expectedQueue, queueOperationProviderService.listQueues(queueFilter).get(0));
-        Mockito.verify(sgeQueueProvider, times(1)).listQueues(queueFilter);
+        Mockito.verify(queueProvider, times(1)).listQueues(queueFilter);
     }
 
     @Test
@@ -72,9 +74,9 @@ public class QueueOperationProviderServiceTest {
                 .build();
         final List<Queue> queues = Collections.singletonList(expectedQueue);
 
-        doReturn(queues).when(sgeQueueProvider).listQueues();
+        doReturn(queues).when(queueProvider).listQueues();
         Assertions.assertEquals(expectedQueue, queueOperationProviderService.listQueues().get(0));
-        Mockito.verify(sgeQueueProvider, times(1)).listQueues();
+        Mockito.verify(queueProvider, times(1)).listQueues();
     }
 
     @Test
@@ -83,9 +85,9 @@ public class QueueOperationProviderServiceTest {
                 .name(TEST_MAIN_NAME)
                 .build();
 
-        doReturn(deletedQueue).when(sgeQueueProvider).deleteQueues(TEST_MAIN_NAME);
+        doReturn(deletedQueue).when(queueProvider).deleteQueues(TEST_MAIN_NAME);
         Assertions.assertEquals(deletedQueue, queueOperationProviderService.deleteQueue(TEST_MAIN_NAME));
-        Mockito.verify(sgeQueueProvider, times(1)).deleteQueues(TEST_MAIN_NAME);
+        Mockito.verify(queueProvider, times(1)).deleteQueues(TEST_MAIN_NAME);
     }
 
     @Test
@@ -99,8 +101,8 @@ public class QueueOperationProviderServiceTest {
                 .ownerList(Collections.singletonList(TEST_OWNER_LIST))
                 .build();
 
-        doReturn(updatedQueue).when(sgeQueueProvider).updateQueue(updateRequest);
+        doReturn(updatedQueue).when(queueProvider).updateQueue(updateRequest);
         Assertions.assertEquals(updatedQueue, queueOperationProviderService.updateQueue(updateRequest));
-        Mockito.verify(sgeQueueProvider, times(1)).updateQueue(updateRequest);
+        Mockito.verify(queueProvider, times(1)).updateQueue(updateRequest);
     }
 }

--- a/src/test/java/com/epam/grid/engine/service/UsageOperationProviderServiceTest.java
+++ b/src/test/java/com/epam/grid/engine/service/UsageOperationProviderServiceTest.java
@@ -19,52 +19,33 @@
 
 package com.epam.grid.engine.service;
 
+import com.epam.grid.engine.TestPropertiesWithSgeEngine;
 import com.epam.grid.engine.entity.usage.UsageReport;
 import com.epam.grid.engine.entity.usage.UsageReportFilter;
-import com.epam.grid.engine.provider.usage.sge.SgeUsageProvider;
+import com.epam.grid.engine.provider.usage.UsageProvider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 
-@SpringBootTest(properties = {"grid.engine.type=SGE"})
+@SpringBootTest
+@TestPropertiesWithSgeEngine
 public class UsageOperationProviderServiceTest {
 
     @Autowired
     UsageOperationProviderService usageOperationProviderService;
 
-    @SpyBean
-    SgeUsageProvider usageProvider;
+    @MockBean
+    UsageProvider usageProvider;
 
     @Test
     public void shouldReturnCorrectResponse() {
-
-        final UsageReport correctReport = reportFill(usageParser());
-
-        doReturn(correctReport).when(usageProvider).getUsageReport(new UsageReportFilter());
-        Assertions.assertEquals(correctReport, usageOperationProviderService.getUsageReport(new UsageReportFilter()));
-        Mockito.verify(usageProvider, times(1)).getUsageReport(new UsageReportFilter());
-    }
-
-    private UsageReport reportFill(final UsageReport usageReport) {
-        return UsageReport.builder()
-                .wallClock(usageReport.getWallClock())
-                .userTime(usageReport.getUserTime())
-                .systemTime(usageReport.getSystemTime())
-                .cpuTime(usageReport.getCpuTime())
-                .memory(usageReport.getMemory())
-                .ioData(usageReport.getIoData())
-                .ioWaiting(usageReport.getIoWaiting())
-                .build();
-    }
-
-    private UsageReport usageParser() {
-        return UsageReport.builder()
+        final UsageReport correctReport = UsageReport.builder()
                 .wallClock(1)
                 .cpuTime(2.0)
                 .ioData(3.00)
@@ -73,5 +54,9 @@ public class UsageOperationProviderServiceTest {
                 .systemTime(6.0)
                 .userTime(7.0)
                 .build();
+
+        doReturn(correctReport).when(usageProvider).getUsageReport(new UsageReportFilter());
+        Assertions.assertEquals(correctReport, usageOperationProviderService.getUsageReport(new UsageReportFilter()));
+        Mockito.verify(usageProvider, times(1)).getUsageReport(new UsageReportFilter());
     }
 }

--- a/src/test/resources/test-application.properties
+++ b/src/test/resources/test-application.properties
@@ -1,0 +1,35 @@
+#
+# /*
+#  * Copyright 2022 EPAM Systems, Inc. (https://www.epam.com/)
+#  *
+#  * Licensed under the Apache License, Version 2.0 (the "License");
+#  * you may not use this file except in compliance with the License.
+#  * You may obtain a copy of the License at
+#  *
+#  *     http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing, software
+#  * distributed under the License is distributed on an "AS IS" BASIS,
+#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  * See the License for the specific language governing permissions and
+#  * limitations under the License.
+#  */
+#
+#
+
+# Common test properties
+# grid.engine.type is defined in the TestPropertiesWithSgeEngine, TestPropertiesWithSlurmEngine classes
+
+spring.jackson.default-property-inclusion = NON_NULL
+command.template.path=templates/
+job.log.dir=${GE_JOB_LOGS:logs}
+api.log.path=${GE_API_LOGS:logs}/
+api.log.keep.days=7
+grid.engine.shared.folder=${GRID_SHARED_FOLDER:./}
+
+#SGE specific properties
+sge.qmaster.port=6444
+sge.execd.port=6445
+sge.qmaster.host.path=/opt/sge/default/common/act_qmaster
+sge.parallel.environment.registration.default.slots=${GRID_ENGINE_API_PE_REGISTRATION_DEFAULT_SLOTS:999}
+sge.parallel.environment.registration.default.allocation.rule=${GRID_ENGINE_API_PE_REG_DEFAULT_ALLOCATION_RULE:$fill_up}


### PR DESCRIPTION
This PR brings ability to use test properties.

Short description:
- added test-application.properties
- added the TestPropertiesWithSgeEngine, TestPropertiesWithSlurmEngine annotations
- changed component test classes using these annotations

also
- refactored some tests
- fixed the @code tag inappropriate usage into javadoc descriptions
